### PR TITLE
Fix reporting functions that never started.

### DIFF
--- a/database.php
+++ b/database.php
@@ -52,6 +52,15 @@ function syslog_db_execute($sql, $log = TRUE) {
 	return db_execute($sql, $log, $syslog_cnn);
 }
 
+/* syslog_db_execute_prepared - run an sql query and do not return any output
+   @arg $sql - the sql query to execute
+   @arg $log - whether to log error messages, defaults to true
+   @returns - '1' for success, '0' for error */
+function syslog_db_execute_prepared($sql, $parms = array(), $log = TRUE) {
+	global $syslog_cnn;
+	return db_execute_prepared($sql, $parms, $log, $syslog_cnn);
+}
+
 /* syslog_db_fetch_cell - run a 'select' sql query and return the first column of the
      first row found
    @arg $sql - the sql query to execute

--- a/functions.php
+++ b/functions.php
@@ -235,7 +235,7 @@ function syslog_remove_items($table, $uniqueID) {
 						(logtime, priority_id, facility_id, program_id, host_id, message)
 						SELECT TIMESTAMP(`" . $syslog_incoming_config['dateField'] . "`, `" . $syslog_incoming_config['timeField']     . "`),
 						priority_id, facility_id, program_id, host_id, message
-						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, si.program_id, si.host_id, si.message
+						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, spg.program_id, sh.host_id, si.message
 							FROM `" . $syslogdb_default . "`.`syslog_incoming` AS si
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_facilities` AS sf
 							ON sf.facility_id=si.facility_id
@@ -244,7 +244,7 @@ function syslog_remove_items($table, $uniqueID) {
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_programs` AS spg
 							ON spg.program=si.program
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_hosts` AS sh
-							ON sh.host_id=si.host_id
+							ON sh.host=si.host
 							WHERE " . $syslog_incoming_config["facilityField"] . "='" . $remove['message'] . "' AND status=" . $uniqueID . ") AS merge";
 				}
 
@@ -274,7 +274,7 @@ function syslog_remove_items($table, $uniqueID) {
 						(logtime, priority_id, facility_id, program_id, host_id, message)
 						SELECT TIMESTAMP(`" . $syslog_incoming_config['dateField'] . "`, `" . $syslog_incoming_config['timeField']     . "`),
 						priority_id, facility_id, program_id, host_id, message
-						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, si.program_id, si.host_id, si.message
+						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, spg.program_id, sh.host_id, si.message
 							FROM `" . $syslogdb_default . "`.`syslog_incoming` AS si
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_facilities` AS sf
 							ON sf.facility_id=si.facility_id
@@ -283,7 +283,7 @@ function syslog_remove_items($table, $uniqueID) {
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_programs` AS spg
 							ON spg.program=si.program
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_hosts` AS sh
-							ON sh.host_id=si.host_id
+							ON sh.host=si.host
 							WHERE host='" . $remove['message'] . "' AND status=" . $uniqueID . ") AS merge";
 				}
 
@@ -313,7 +313,7 @@ function syslog_remove_items($table, $uniqueID) {
 						(logtime, priority_id, facility_id, program_id, host_id, message)
 						SELECT TIMESTAMP(`" . $syslog_incoming_config['dateField'] . "`, `" . $syslog_incoming_config['timeField'] . "`),
 						priority_id, facility_id, program_id, host_id, message
-						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, si.program_id, si.host_id, si.message
+						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, spg.program_id, sh.host_id, si.message
 							FROM `" . $syslogdb_default . "`.`syslog_incoming` AS si
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_facilities` AS sf
 							ON sf.facility_id=si.facility_id
@@ -322,7 +322,7 @@ function syslog_remove_items($table, $uniqueID) {
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_programs` AS spg
 							ON spg.program=si.program
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_hosts` AS sh
-							ON sh.host_id=si.host_id
+							ON sh.host=si.host
 							WHERE message LIKE '" . $remove['message'] . "%' AND status=" . $uniqueID . ") AS merge";
 				}
 
@@ -350,7 +350,7 @@ function syslog_remove_items($table, $uniqueID) {
 						(logtime, priority_id, facility_id, program_id, host_id, message)
 						SELECT TIMESTAMP(`" . $syslog_incoming_config['dateField'] . "`, `" . $syslog_incoming_config['timeField'] . "`),
 						priority_id, facility_id, program_id, host_id, message
-						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, si.program_id, si.host_id, si.message
+						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, spg.program_id, sh.host_id, si.message
 							FROM `" . $syslogdb_default . "`.`syslog_incoming` AS si
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_facilities` AS sf
 							ON sf.facility_id=si.facility_id
@@ -359,7 +359,7 @@ function syslog_remove_items($table, $uniqueID) {
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_programs` AS spg
 							ON spg.program=si.program
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_hosts` AS sh
-							ON sh.host_id=si.host_id
+							ON sh.host=si.host
 							WHERE message LIKE '%" . $remove['message'] . "%' AND status=" . $uniqueID . ") AS merge";
 				}
 
@@ -387,7 +387,7 @@ function syslog_remove_items($table, $uniqueID) {
 						(logtime, priority_id, facility_id, program_id, host_id, message)
 						SELECT TIMESTAMP(`" . $syslog_incoming_config['dateField'] . "`, `" . $syslog_incoming_config['timeField'] . "`),
 						priority_id, facility_id, program_id, host_id, message
-						FROM (SELECT date, time, priority_id, facility_id, program_id, host_id, message
+						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, spg.program_id, sh.host_id, si.message
 							FROM `" . $syslogdb_default . "`.`syslog_incoming` AS si
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_facilities` AS sf
 							ON sf.facility_id=si.facility_id
@@ -396,7 +396,7 @@ function syslog_remove_items($table, $uniqueID) {
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_programs` AS spg
 							ON spg.program=si.program
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_hosts` AS sh
-							ON sh.host_id=si.host_id
+							ON sh.host=si.host
 							WHERE message LIKE '%" . $remove['message'] . "' AND status=" . $uniqueID . ") AS merge";
 				}
 
@@ -424,7 +424,7 @@ function syslog_remove_items($table, $uniqueID) {
 						(logtime, priority_id, facility_id, program_id, host_id, message)
 						SELECT TIMESTAMP(`" . $syslog_incoming_config['dateField'] . "`, `" . $syslog_incoming_config['timeField'] . "`),
 						priority_id, facility_id, program_id, host_id, message
-						FROM (SELECT date, time, priority_id, facility_id, program_id, host_id, message
+						FROM (SELECT si.date, si.time, si.priority_id, si.facility_id, spg.program_id, sh.host_id, si.message
 							FROM `" . $syslogdb_default . "`.`syslog_incoming` AS si
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_facilities` AS sf
 							ON sf.facility_id=si.facility_id
@@ -433,7 +433,7 @@ function syslog_remove_items($table, $uniqueID) {
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_programs` AS spg
 							ON spg.program=si.program
 							INNER JOIN `" . $syslogdb_default . "`.`syslog_hosts` AS sh
-							ON sh.host_id=si.host_id
+							ON sh.host=si.host
 							WHERE (" . $remove['message'] . ") AND status=" . $uniqueID . ") AS merge";
 				}
 

--- a/syslog.sql
+++ b/syslog.sql
@@ -219,7 +219,7 @@ CREATE TABLE `syslog_reports` (
   `type` varchar(16) NOT NULL DEFAULT '',
   `enabled` char(2) DEFAULT 'on',
   `timespan` int(16) NOT NULL DEFAULT '0',
-  `timepart` char(5) NOT NULL DEFAULT '00:00',
+  `timepart` int(5) NOT NULL DEFAULT '0',
   `lastsent` int(16) NOT NULL DEFAULT '0',
   `body` varchar(1024) DEFAULT NULL,
   `message` varchar(128) DEFAULT NULL,


### PR DESCRIPTION
Fix missmatch of time expression in `timepart`, `$base_start_time` between database schema, `syslog_proccess.php` and `syslog_report.php`.
I thought whether it was Integer or Char, but I unified it with an easily computable integer. Therefore, a change has occurred in the database schema.

Since `syslog_process.php` refers to cacti_db instead of syslog_db, I have created a function equivalent to cacti's `database.php#db_execute_prepared()` in syslog's `database.php`.

I also added some missing filtering criteria in `syslog_process.php`.

For now, I have focused on running reporting functions.

Best regards.
