### PR TITLE
Fixed two issues: SQL Error: Unknown column 'logtime' in 'field list' and PHP Warning: include(./include/cli_check.php): failed to open stream:

### DIFF
--- a/INFO
+++ b/INFO
@@ -5,5 +5,5 @@ longname = Syslog Monitoring
 author = The Cacti Group
 email = 
 homepage = http://www.cacti.net
-compat = 1.2.8
+compat = 1.2.10
 capabilities = online_view:1, online_mgmt:1, offline_view:0, offline_mgmt:0, remote_collect:0

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ that.
 
 ## ChangeLog
 
+--- develop ---
+
+* issue#116: Background process fail to operate syslog_coming table; syslog_process.php fail if current workdir is not CACTI_TOP
+
 --- 2.7 ---
 
 * issue#110: Syslog Alerts cause DB errors

--- a/setup.php
+++ b/setup.php
@@ -212,7 +212,7 @@ function syslog_check_upgrade() {
 
 	// Let's only run this check if we are on a page that actually needs the data
 	$files = array('plugins.php', 'syslog.php', 'syslog_removal.php', 'syslog_alerts.php', 'syslog_reports.php');
-	if (!in_array(get_current_page(), $files)) {
+	if (substr($_SERVER['SCRIPT_FILENAME'], -18) != 'syslog_process.php' &&  !in_array(get_current_page(), $files)) {
 		return;
 	}
 

--- a/syslog_process.php
+++ b/syslog_process.php
@@ -22,10 +22,9 @@
  +-------------------------------------------------------------------------+
 */
 
-include('./include/cli_check.php');
-include_once('./lib/poller.php');
-include('./plugins/syslog/config.php');
-include_once('./plugins/syslog/functions.php');
+include(dirname(__FILE__) . '/../../include/cli_check.php');
+include(dirname(__FILE__) . '/config.php');
+include_once(dirname(__FILE__) . '/functions.php');
 
 /* Let it run for an hour if it has to, to clear up any big
  * bursts of incoming syslog events


### PR DESCRIPTION
1. SQL Error: Unknown column 'logtime' in 'field list' between deploy v2.7, and access any syslog web page, 
2. If exec syslog_process.php our of CACTI_TOP, 
    PHP Warning:  include(./include/cli_check.php): failed to open stream: No such file or directory in /var/www/html/cacti/plugins/syslog/syslog_process.php on line 25
3. Remove `include...lib/poller.php` after Cacti core 1.2.10 include lib/poller.php in global.php 
