### PR TITLE
Fixed: deprecated curly braces for array index in PHP 7.4

### DIFF
--- a/syslog_alerts.php
+++ b/syslog_alerts.php
@@ -139,7 +139,7 @@ function form_actions() {
 
 	form_start('syslog_alerts.php');
 
-	html_start_box($syslog_actions{get_request_var('drp_action')}, '60%', '', '3', 'center', '');
+	html_start_box($syslog_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
 
 	/* setup some variables */
 	$alert_array = array(); $alert_list = '';

--- a/syslog_removal.php
+++ b/syslog_removal.php
@@ -149,7 +149,7 @@ function form_actions() {
 
 	form_start('syslog_removal.php');
 
-	html_start_box($syslog_actions{get_request_var('drp_action')}, '60%', '', '3', 'center', '');
+	html_start_box($syslog_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
 
 	/* setup some variables */
 	$removal_array = array(); $removal_list = '';

--- a/syslog_reports.php
+++ b/syslog_reports.php
@@ -136,7 +136,7 @@ function form_actions() {
 
 	form_start('syslog_reports.php');
 
-	html_start_box($syslog_actions{get_request_var('drp_action')}, '60%', '', '3', 'center', '');
+	html_start_box($syslog_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
 
 	/* setup some variables */
 	$report_array = array(); $report_list = '';


### PR DESCRIPTION
Same fix as Cacti/cacti#2859