### PR TITLE
fix: execute replication CREATE TABLE SQL from SHOW CREATE output

### DIFF
--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -187,6 +187,16 @@ jobs:
           echo "Syntax errors found!"
           exit 1
         fi
+
+    - name: Run Plugin Regression Tests
+      run: |
+        cd ${{ github.workspace }}/cacti/plugins/syslog
+        if [ -d tests/regression ]; then
+          for test in tests/regression/*.php; do
+            [ -f "$test" ] || continue
+            php "$test"
+          done
+        fi
     
     
     - name: Run Cacti Poller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 --- develop ---
 
 * issue#250: Fix date filter persistence by validating before shift_span detection
+* issue#258: Execute CREATE TABLE SQL correctly during replication sync
 * issue: Making changes to support Cacti 1.3
 * issue: Don't use MyISAM for non-analytical tables
 * issue: The install advisor for Syslog was broken in current Cacti releases

--- a/setup.php
+++ b/setup.php
@@ -817,6 +817,7 @@ function syslog_replace_data($table, &$data) {
 		$sqlData  = array();
 		$sqlQuery = array();
 		$columns  = array_keys($data[0]);
+		$create_sql = '';
 
 		$create = db_fetch_row('SHOW CREATE TABLE ' . $table);
 		if (isset($create["CREATE TABLE `$table`"]) || isset($create['Create Table'])) {
@@ -828,7 +829,12 @@ function syslog_replace_data($table, &$data) {
 		}
 
 		if (!syslog_db_table_exists($table)) {
-			syslog_db_execute($create);
+			if ($create_sql == '') {
+				cacti_log('WARNING: Unable to derive CREATE TABLE SQL for `' . $table . '` during Syslog replication.', false, 'REPLICATE');
+				return;
+			}
+
+			syslog_db_execute($create_sql);
 			syslog_db_execute("TRUNCATE TABLE $table");
 		}
 

--- a/tests/regression/issue258_replication_create_sql_test.php
+++ b/tests/regression/issue258_replication_create_sql_test.php
@@ -1,0 +1,121 @@
+<?php
+
+$existing_functions = array(
+	'db_fetch_row',
+	'syslog_db_table_exists',
+	'syslog_db_execute',
+	'syslog_db_execute_prepared'
+);
+
+foreach ($existing_functions as $existing_function) {
+	if (function_exists($existing_function)) {
+		fwrite(STDERR, "This test must run in isolated mode; function already exists: $existing_function\n");
+		exit(1);
+	}
+}
+
+if (!function_exists('cacti_sizeof')) {
+	function cacti_sizeof($value) {
+		if (is_array($value) || $value instanceof Countable) {
+			return count($value);
+		}
+
+		return 0;
+	}
+}
+
+$GLOBALS['syslog_replace_data_execute_calls'] = array();
+$GLOBALS['syslog_replace_data_prepared_calls'] = array();
+$GLOBALS['issue258_logs'] = array();
+$GLOBALS['issue258_show_create'] = array('Create Table' => 'CREATE TABLE `syslog_alert` (`id` INT NOT NULL)');
+
+if (!function_exists('db_fetch_row')) {
+	function db_fetch_row($sql) {
+		return $GLOBALS['issue258_show_create'];
+	}
+}
+
+if (!function_exists('syslog_db_table_exists')) {
+	function syslog_db_table_exists($table) {
+		return false;
+	}
+}
+
+if (!function_exists('syslog_db_execute')) {
+	function syslog_db_execute($sql) {
+		$GLOBALS['syslog_replace_data_execute_calls'][] = $sql;
+
+		return true;
+	}
+}
+
+if (!function_exists('syslog_db_execute_prepared')) {
+	function syslog_db_execute_prepared($sql, $params) {
+		$GLOBALS['syslog_replace_data_prepared_calls'][] = array(
+			'sql'    => $sql,
+			'params' => $params
+		);
+
+		return true;
+	}
+}
+
+if (!function_exists('cacti_log')) {
+	function cacti_log($message, $output = false, $facility = 'SYSTEM', $level = '') {
+		$GLOBALS['issue258_logs'][] = $message;
+	}
+}
+
+require_once dirname(__DIR__, 2) . '/setup.php';
+
+$data = array(
+	array(
+		'id'   => 1,
+		'hash' => 'abc123',
+		'name' => 'sample'
+	)
+);
+
+syslog_replace_data('syslog_alert', $data);
+
+$executed = $GLOBALS['syslog_replace_data_execute_calls'];
+
+if (cacti_sizeof($executed) < 2) {
+	fwrite(STDERR, "Expected CREATE + TRUNCATE calls to run.\n");
+	exit(1);
+}
+
+if ($executed[0] !== 'CREATE TABLE `syslog_alert` (`id` INT NOT NULL)') {
+	fwrite(STDERR, "Expected CREATE TABLE SQL to be executed from create_sql.\n");
+	exit(1);
+}
+
+if ($executed[1] !== 'TRUNCATE TABLE syslog_alert') {
+	fwrite(STDERR, "Expected TRUNCATE TABLE to run after CREATE TABLE.\n");
+	exit(1);
+}
+
+$prepared = $GLOBALS['syslog_replace_data_prepared_calls'];
+
+if (cacti_sizeof($prepared) !== 1) {
+	fwrite(STDERR, "Expected a single prepared INSERT statement execution.\n");
+	exit(1);
+}
+
+$GLOBALS['syslog_replace_data_execute_calls']  = array();
+$GLOBALS['syslog_replace_data_prepared_calls'] = array();
+$GLOBALS['issue258_show_create'] = false;
+
+syslog_replace_data('syslog_alert', $data);
+
+if (cacti_sizeof($GLOBALS['syslog_replace_data_execute_calls']) !== 0) {
+	fwrite(STDERR, "Expected no execute calls when CREATE TABLE SQL is unavailable.\n");
+	exit(1);
+}
+
+if (cacti_sizeof($GLOBALS['syslog_replace_data_prepared_calls']) !== 0) {
+	fwrite(STDERR, "Expected no prepared inserts when CREATE TABLE SQL is unavailable.\n");
+	exit(1);
+}
+
+echo "issue258_replication_create_sql_test passed\n";


### PR DESCRIPTION
## Summary
- execute the `CREATE TABLE` statement text (`$create_sql`) when a replicated rules table is missing
- initialize and guard `create_sql` before execution in `syslog_replace_data()`
- if CREATE SQL cannot be derived, log a replication warning and return safely
- keep the existing truncate + bulk upsert replication flow unchanged
- add regression coverage for `syslog_replace_data()` table bootstrap path
- harden regression test isolation to avoid accidental real DB execution
- run regression scripts from CI when `tests/regression/*.php` exist
- add changelog entry for issue #258

## Validation
- php -l setup.php
- php -l tests/regression/issue258_replication_create_sql_test.php
- php tests/regression/issue258_replication_create_sql_test.php

Fixes #258