### PR TITLE
hardening: replace eval callback execution in autocomplete handling

### DIFF
--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -187,6 +187,16 @@ jobs:
           echo "Syntax errors found!"
           exit 1
         fi
+
+    - name: Run Plugin Regression Tests
+      run: |
+        cd ${{ github.workspace }}/cacti/plugins/syslog
+        if [ -d tests/regression ]; then
+          for test in tests/regression/*.php; do
+            [ -f "$test" ] || continue
+            php "$test"
+          done
+        fi
     
     
     - name: Run Cacti Poller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 --- develop ---
 
 * issue#250: Fix date filter persistence by validating before shift_span detection
+* issue#260: Replace eval-based callback execution in autocomplete handling
 * issue: Making changes to support Cacti 1.3
 * issue: Don't use MyISAM for non-analytical tables
 * issue: The install advisor for Syslog was broken in current Cacti releases

--- a/js/functions.js
+++ b/js/functions.js
@@ -568,6 +568,25 @@ function initSyslogReports() {
  * ======================================================================== */
 
 /**
+ * Validate and invoke a named callback function specified as a string
+ * @param {string} onChange - Name of the global function to call (e.g. 'myCallback')
+ */
+function runSyslogAutocompleteOnChange(onChange) {
+	if (typeof onChange !== 'string') {
+		return;
+	}
+
+	var callbackName = onChange.trim().replace(/\(\)\s*$/, '');
+	if (!callbackName.match(/^[A-Za-z_$][A-Za-z0-9_$]*$/)) {
+		return;
+	}
+
+	if (typeof window[callbackName] === 'function') {
+		window[callbackName]();
+	}
+}
+
+/**
  * Initialize autocomplete for form dropdown fields
  * @param {string} formName - The name of the form field
  * @param {string} callback - The AJAX callback action
@@ -591,7 +610,7 @@ function initSyslogAutocomplete(formName, callback, onChange) {
 					$('#' + formName).val(ui.item.value);
 				}
 				if (onChange) {
-					eval(onChange);
+					runSyslogAutocompleteOnChange(onChange);
 				}
 			}
 		}).css('border', 'none').css('background-color', 'transparent');

--- a/tests/regression/issue260_remove_eval_callback_test.php
+++ b/tests/regression/issue260_remove_eval_callback_test.php
@@ -1,0 +1,45 @@
+<?php
+
+$javascript = file_get_contents(dirname(__DIR__, 2) . '/js/functions.js');
+
+if ($javascript === false) {
+	fwrite(STDERR, "Failed to load js/functions.js\n");
+	exit(1);
+}
+
+if (strpos($javascript, 'eval(') !== false) {
+	fwrite(STDERR, "Unsafe eval() callback execution is still present.\n");
+	exit(1);
+}
+
+if (!preg_match('/function\s+runSyslogAutocompleteOnChange\s*\(\s*onChange\s*\)/', $javascript)) {
+	fwrite(STDERR, "Safe autocomplete callback helper is missing.\n");
+	exit(1);
+}
+
+if (strpos($javascript, "if (!callbackName.match(/^[A-Za-z_$][A-Za-z0-9_$]*$/))") === false) {
+	fwrite(STDERR, "Autocomplete callback name validation is missing.\n");
+	exit(1);
+}
+
+$hasCallbackTypeCheck = preg_match(
+	'/if\s*\(\s*typeof\s+window\s*\[\s*callbackName\s*\]\s*===\s*[\'"]{1}function[\'"]{1}\s*\)/',
+	$javascript
+) === 1;
+
+$hasCallbackInvocation = preg_match(
+	'/window\s*\[\s*callbackName\s*\]\s*\(/',
+	$javascript
+) === 1;
+
+if (!$hasCallbackTypeCheck || !$hasCallbackInvocation) {
+	fwrite(STDERR, "Expected function-reference callback execution is missing.\n");
+	exit(1);
+}
+
+if (strpos($javascript, 'runSyslogAutocompleteOnChange(onChange);') === false) {
+	fwrite(STDERR, "Autocomplete select handler is not using safe callback execution.\n");
+	exit(1);
+}
+
+echo "issue260_remove_eval_callback_test passed\n";


### PR DESCRIPTION
## Summary
- replace `eval(onChange)` with safe function-reference execution in `initSyslogAutocomplete()`
- validate callback names before invocation and execute only named global functions
- add regression coverage for removing eval usage
- run regression scripts from CI when `tests/regression/*.php` exist
- add changelog entry for issue #260

## Validation
- php -l tests/regression/issue260_remove_eval_callback_test.php
- php tests/regression/issue260_remove_eval_callback_test.php

Fixes #260