### PR TITLE
bugfix: scope partition maintenance to target table and lock create path

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -187,86 +187,184 @@ function syslog_partition_manage() {
 }
 
 /**
- * This function will create a new partition for the specified table.
+ * Validate tables that support partition maintenance.
+ *
+ * Any value added to the allowlist MUST match ^[a-z_]+$ so it is safe
+ * for identifier interpolation in DDL statements (MySQL does not support
+ * parameter binding for identifiers).
+ */
+function syslog_partition_table_allowed($table) {
+	if (!in_array($table, array('syslog', 'syslog_removed'), true)) {
+		return false;
+	}
+
+	/* Defense-in-depth: reject values unsafe for identifier interpolation. */
+	if (!preg_match('/^[a-z_]+$/', $table)) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Create a new partition for the specified table.
+ *
+ * @return bool true on success, false on lock failure or disallowed table.
  */
 function syslog_partition_create($table) {
 	global $syslogdb_default;
 
-	/* determine the format of the table name */
-	$time    = time();
-	$cformat = 'd' . date('Ymd', $time);
-	$lnow    = date('Y-m-d', $time+86400);
-
-	$exists = syslog_db_fetch_row("SELECT *
-		FROM `information_schema`.`partitions`
-        WHERE table_schema='" . $syslogdb_default . "'
-		AND partition_name='" . $cformat . "'
-		AND table_name='syslog'
-        ORDER BY partition_ordinal_position");
-
-	if (!cacti_sizeof($exists)) {
-		cacti_log("SYSLOG: Creating new partition '$cformat'", false, 'SYSTEM');
-
-		syslog_debug("Creating new partition '$cformat'");
-
-		syslog_db_execute("ALTER TABLE `" . $syslogdb_default . "`.`$table` REORGANIZE PARTITION dMaxValue INTO (
-			PARTITION $cformat VALUES LESS THAN (TO_DAYS('$lnow')),
-			PARTITION dMaxValue VALUES LESS THAN MAXVALUE)");
+	if (!syslog_partition_table_allowed($table)) {
+		return false;
 	}
+
+	/* Hash to guarantee the lock name stays within MySQL's 64-byte limit. */
+	$lock_name = substr(hash('sha256', $syslogdb_default . '.syslog_partition_create.' . $table), 0, 60);
+
+	/*
+	 * 10-second timeout is sufficient: partition maintenance runs once per
+	 * poller cycle (typically 5 minutes), so sustained contention is not
+	 * expected. A failure is logged so monitoring can detect repeated misses.
+	 */
+	$locked    = syslog_db_fetch_cell_prepared('SELECT GET_LOCK(?, 10)', array($lock_name));
+
+	if ($locked === null) {
+		/* NULL means the GET_LOCK call itself failed, not just contention. */
+		cacti_log("SYSLOG: GET_LOCK call failed for partition create on '$table'", false, 'SYSTEM');
+		return false;
+	}
+
+	if ((int)$locked !== 1) {
+		cacti_log("SYSLOG: Unable to acquire partition create lock for '$table'", false, 'SYSTEM');
+		return false;
+	}
+
+	try {
+		/* determine the format of the table name */
+		$time    = time();
+		$cformat = 'd' . date('Ymd', $time);
+		$lnow    = date('Y-m-d', $time+86400);
+
+		$exists = syslog_db_fetch_row_prepared("SELECT *
+			FROM `information_schema`.`partitions`
+			WHERE table_schema = ?
+			AND partition_name = ?
+			AND table_name = ?
+			ORDER BY partition_ordinal_position",
+			array($syslogdb_default, $cformat, $table));
+
+		if (!cacti_sizeof($exists)) {
+			cacti_log("SYSLOG: Creating new partition '$cformat'", false, 'SYSTEM');
+
+			syslog_debug("Creating new partition '$cformat'");
+
+			/*
+			 * MySQL does not support parameter binding for DDL identifiers
+			 * or partition definitions. $table is safe because it passed
+			 * syslog_partition_table_allowed() (two-value allowlist plus
+			 * regex guard). $cformat and $lnow derive from date() and
+			 * contain only digits, hyphens, and the letter 'd'.
+			 */
+			syslog_db_execute("ALTER TABLE `" . $syslogdb_default . "`.`$table` REORGANIZE PARTITION dMaxValue INTO (
+				PARTITION $cformat VALUES LESS THAN (TO_DAYS('$lnow')),
+				PARTITION dMaxValue VALUES LESS THAN MAXVALUE)");
+		}
+	} finally {
+		syslog_db_fetch_cell_prepared('SELECT RELEASE_LOCK(?)', array($lock_name));
+	}
+
+	return true;
 }
 
 /**
- * This function will remove all old partitions for the specified table.
+ * Remove old partitions for the specified table.
  */
 function syslog_partition_remove($table) {
 	global $syslogdb_default;
 
+	if (!syslog_partition_table_allowed($table)) {
+		cacti_log("SYSLOG: partition_remove called with disallowed table '$table'", false, 'SYSTEM');
+		return 0;
+	}
+
+	$lock_name = substr(hash('sha256', $syslogdb_default . '.syslog_partition_remove.' . $table), 0, 60);
+
+	$locked = syslog_db_fetch_cell_prepared('SELECT GET_LOCK(?, 10)', array($lock_name));
+
+	if ($locked === null) {
+		cacti_log("SYSLOG: GET_LOCK call failed for partition remove on '$table'", false, 'SYSTEM');
+		return 0;
+	}
+
+	if ((int)$locked !== 1) {
+		cacti_log("SYSLOG: Unable to acquire partition remove lock for '$table'", false, 'SYSTEM');
+		return 0;
+	}
+
 	$syslog_deleted = 0;
-	$number_of_partitions = syslog_db_fetch_assoc("SELECT *
-		FROM `information_schema`.`partitions`
-		WHERE table_schema='" . $syslogdb_default . "' AND table_name='syslog'
-		ORDER BY partition_ordinal_position");
 
-	$days = read_config_option('syslog_retention');
+	try {
+		$number_of_partitions = syslog_db_fetch_assoc_prepared("SELECT *
+			FROM `information_schema`.`partitions`
+			WHERE table_schema = ? AND table_name = ?
+			ORDER BY partition_ordinal_position",
+			array($syslogdb_default, $table));
 
-	syslog_debug("There are currently '" . sizeof($number_of_partitions) . "' Syslog Partitions, We will keep '$days' of them.");
+		$days = read_config_option('syslog_retention');
 
-	if ($days > 0) {
-		$user_partitions = sizeof($number_of_partitions) - 1;
-		if ($user_partitions >= $days) {
-			$i = 0;
-			while ($user_partitions > $days) {
-				$oldest = $number_of_partitions[$i];
+		syslog_debug("There are currently '" . sizeof($number_of_partitions) . "' Syslog Partitions, We will keep '$days' of them.");
 
-				cacti_log("SYSLOG: Removing old partition '" . $oldest['PARTITION_NAME'] . "'", false, 'SYSTEM');
+		if ($days > 0) {
+			$user_partitions = sizeof($number_of_partitions) - 1;
+			if ($user_partitions >= $days) {
+				$i = 0;
+				while ($user_partitions > $days) {
+					$oldest = $number_of_partitions[$i];
 
-				syslog_debug("Removing partition '" . $oldest['PARTITION_NAME'] . "'");
+					cacti_log("SYSLOG: Removing old partition '" . $oldest['PARTITION_NAME'] . "'", false, 'SYSTEM');
 
-				syslog_db_execute("ALTER TABLE `" . $syslogdb_default . "`.`$table` DROP PARTITION " . $oldest['PARTITION_NAME']);
+					syslog_debug("Removing partition '" . $oldest['PARTITION_NAME'] . "'");
 
-				$i++;
-				$user_partitions--;
-				$syslog_deleted++;
+					syslog_db_execute("ALTER TABLE `" . $syslogdb_default . "`.`$table` DROP PARTITION " . $oldest['PARTITION_NAME']);
+
+					$i++;
+					$user_partitions--;
+					$syslog_deleted++;
+				}
 			}
 		}
+	} finally {
+		syslog_db_fetch_cell_prepared('SELECT RELEASE_LOCK(?)', array($lock_name));
 	}
 
 	return $syslog_deleted;
 }
 
+/*
+ * syslog_partition_check is a read-only SELECT against information_schema.
+ * It does not execute DDL, so it does not need the named lock that
+ * syslog_partition_create and syslog_partition_remove acquire. External
+ * serialization is provided by the poller cycle calling
+ * syslog_partition_manage().
+ */
 function syslog_partition_check($table) {
 	global $syslogdb_default;
+
+	if (!syslog_partition_table_allowed($table)) {
+		return false;
+	}
 
 	if (defined('SYSLOG_CONFIG')) {
 		include(SYSLOG_CONFIG);
 	}
 
 	/* find date of last partition */
-	$last_part = syslog_db_fetch_cell("SELECT PARTITION_NAME
+	$last_part = syslog_db_fetch_cell_prepared("SELECT PARTITION_NAME
 		FROM `information_schema`.`partitions`
-		WHERE table_schema='" . $syslogdb_default . "' AND table_name='syslog'
+		WHERE table_schema = ? AND table_name = ?
 		ORDER BY partition_ordinal_position DESC
-		LIMIT 1,1;");
+		LIMIT 1,1",
+		array($syslogdb_default, $table));
 
 	$lformat   = str_replace('d', '', $last_part);
 	$cformat   = date('Ymd');
@@ -2421,4 +2519,3 @@ function alert_replace_variables($alert, $results, $hostname = '') {
 
 	return $command;
 }
-

--- a/tests/regression/issue254_partition_table_locking_test.php
+++ b/tests/regression/issue254_partition_table_locking_test.php
@@ -1,0 +1,189 @@
+<?php
+
+$functions = file_get_contents(dirname(__DIR__, 2) . '/functions.php');
+
+if ($functions === false) {
+	fwrite(STDERR, "Failed to load functions.php\n");
+	exit(1);
+}
+
+/* All three information_schema queries must be prepared statements
+ * scoped to the requested table via a placeholder. Match only calls
+ * whose first argument contains 'information_schema' to exclude the
+ * GET_LOCK / RELEASE_LOCK uses of syslog_db_fetch_cell_prepared. */
+$partition_query_count = preg_match_all('/syslog_db_fetch_(?:row|assoc|cell)_prepared\s*\([^)]*information_schema/', $functions);
+if ($partition_query_count === false || $partition_query_count !== 3) {
+	fwrite(STDERR, "Partition queries are not consistently scoped to the requested table.\n");
+	exit(1);
+}
+
+if (!preg_match('/SELECT\s+GET_LOCK\s*\(\s*\?\s*,\s*10\s*\)/', $functions)) {
+	fwrite(STDERR, "Partition create lock acquisition is missing.\n");
+	exit(1);
+}
+
+if (!preg_match('/SELECT\s+RELEASE_LOCK\s*\(\s*\?\s*\)/', $functions)) {
+	fwrite(STDERR, "Partition create lock release is missing.\n");
+	exit(1);
+}
+
+if (!preg_match('/function\s+syslog_partition_table_allowed\s*\(/', $functions)) {
+	fwrite(STDERR, "Partition table validation helper is missing.\n");
+	exit(1);
+}
+
+/* RELEASE_LOCK must appear inside a finally block, not just anywhere in the function. */
+if (!preg_match('/finally\s*\{[^}]*RELEASE_LOCK/s', $functions)) {
+	fwrite(STDERR, "RELEASE_LOCK is not inside a finally block; lock may be held on exception.\n");
+	exit(1);
+}
+
+/* The allowlist must be exactly the two known partition tables, nothing else. */
+if (!preg_match("/in_array\(\s*\\\$table\s*,\s*array\s*\(\s*'syslog'\s*,\s*'syslog_removed'\s*\)\s*,\s*true\s*\)/", $functions)) {
+	fwrite(STDERR, "syslog_partition_table_allowed allowlist is not exactly ['syslog', 'syslog_removed'].\n");
+	exit(1);
+}
+
+/* syslog_partition_table_allowed must exist and the allowlist must reject non-member values
+ * (verified above via exact allowlist match -- no additional entries can exist). */
+
+/* syslog_partition_check must return false in its guard clause for disallowed tables. */
+if (!preg_match('/function\s+syslog_partition_check\s*\(\s*\$table\s*\)\s*\{(.{0,400})/s', $functions, $m_check)) {
+	fwrite(STDERR, "syslog_partition_check function not found.\n");
+	exit(1);
+}
+if (!preg_match('/!syslog_partition_table_allowed[^}]*return\s+false/s', $m_check[1])) {
+	fwrite(STDERR, "syslog_partition_check does not return false for disallowed tables.\n");
+	exit(1);
+}
+
+/* syslog_partition_remove must return 0 in its guard clause for disallowed tables. */
+if (!preg_match('/function\s+syslog_partition_remove\s*\(\s*\$table\s*\)\s*\{(.{0,400})/s', $functions, $m_remove)) {
+	fwrite(STDERR, "syslog_partition_remove function not found.\n");
+	exit(1);
+}
+if (!preg_match('/!syslog_partition_table_allowed[^}]*return\s+0/s', $m_remove[1])) {
+	fwrite(STDERR, "syslog_partition_remove does not return 0 for disallowed tables.\n");
+	exit(1);
+}
+
+/* syslog_partition_remove's information_schema query must bind table_name via placeholder. */
+if (!preg_match('/function\s+syslog_partition_remove\s*\(\s*\$table\s*\)\s*\{(.{0,1500})/s', $functions, $m_remove_full)) {
+	fwrite(STDERR, "syslog_partition_remove function body not found.\n");
+	exit(1);
+}
+if (!preg_match('/syslog_db_fetch_(?:row|assoc|cell)_prepared[^)]*information_schema[^)]*table_name\s*=\s*\?/s', $m_remove_full[1])) {
+	fwrite(STDERR, "syslog_partition_remove information_schema query is not scoped to table_name via placeholder.\n");
+	exit(1);
+}
+
+/* ---- Allowlist acceptance / rejection tests ---- */
+
+/* syslog_partition_table_allowed must accept exactly these two values. */
+$allowed_tables = array('syslog', 'syslog_removed');
+foreach ($allowed_tables as $t) {
+	if (!preg_match("/in_array\(\s*\\\$table\s*,\s*array\s*\(\s*'syslog'\s*,\s*'syslog_removed'\s*\)/", $functions)) {
+		fwrite(STDERR, "Allowlist does not contain expected table '$t'.\n");
+		exit(1);
+	}
+}
+
+/* The allowlist function must reject values not in the list by returning false. */
+if (!preg_match('/function\s+syslog_partition_table_allowed\s*\(\s*\$table\s*\)\s*\{(.{0,600})/s', $functions, $m_allowed)) {
+	fwrite(STDERR, "syslog_partition_table_allowed function not found.\n");
+	exit(1);
+}
+if (!preg_match('/return\s+false/', $m_allowed[1])) {
+	fwrite(STDERR, "syslog_partition_table_allowed does not explicitly return false for non-members.\n");
+	exit(1);
+}
+
+/* Defense-in-depth: the allowlist function must include a regex guard for safe identifiers. */
+if (!preg_match('/preg_match.*\[a-z_\]/', $m_allowed[1])) {
+	fwrite(STDERR, "syslog_partition_table_allowed is missing regex defense-in-depth guard.\n");
+	exit(1);
+}
+
+/* ---- Lock name must be scoped to both database and table ---- */
+
+/* The lock name hash input must include both $syslogdb_default and $table. */
+if (!preg_match('/hash\s*\(\s*[\'"]sha256[\'"]\s*,\s*\$syslogdb_default\s*\.\s*[\'"][^"\']*[\'"]\s*\.\s*\$table\s*\)/', $functions)) {
+	fwrite(STDERR, "Lock name hash does not include both database and table.\n");
+	exit(1);
+}
+
+/* ---- syslog_partition_remove must log when called with a disallowed table ---- */
+
+if (!preg_match('/function\s+syslog_partition_remove\s*\(\s*\$table\s*\)\s*\{(.{0,600})/s', $functions, $m_remove_log)) {
+	fwrite(STDERR, "syslog_partition_remove function not found for log check.\n");
+	exit(1);
+}
+if (!preg_match('/!syslog_partition_table_allowed.*cacti_log.*disallowed.*return\s+0/s', $m_remove_log[1])) {
+	fwrite(STDERR, "syslog_partition_remove does not log a warning for disallowed tables.\n");
+	exit(1);
+}
+
+/* ---- DDL safety comment must exist near ALTER TABLE in syslog_partition_create ---- */
+
+if (!preg_match('/MySQL does not support parameter binding for DDL/', $functions)) {
+	fwrite(STDERR, "Missing DDL safety comment in syslog_partition_create.\n");
+	exit(1);
+}
+
+/* ---- No raw (non-prepared) information_schema partition queries may exist ---- */
+
+$raw_partition_queries = preg_match_all('/syslog_db_fetch_(?:row|assoc|cell)\s*\([^)]*information_schema/', $functions);
+if ($raw_partition_queries !== false && $raw_partition_queries > 0) {
+	fwrite(STDERR, "Found $raw_partition_queries raw (non-prepared) information_schema partition queries; all must use _prepared.\n");
+	exit(1);
+}
+
+/* ---- syslog_partition_remove must also use GET_LOCK / RELEASE_LOCK in a finally block ---- */
+
+if (!preg_match('/function\s+syslog_partition_remove\s*\(\s*\$table\s*\)\s*\{(.{0,2500})\n\}/s', $functions, $m_remove_lock)) {
+	fwrite(STDERR, "syslog_partition_remove function body not found for lock check.\n");
+	exit(1);
+}
+if (!preg_match('/GET_LOCK/', $m_remove_lock[1])) {
+	fwrite(STDERR, "syslog_partition_remove does not acquire a lock before ALTER TABLE.\n");
+	exit(1);
+}
+if (!preg_match('/finally\s*\{[^}]*RELEASE_LOCK/s', $m_remove_lock[1])) {
+	fwrite(STDERR, "syslog_partition_remove does not release its lock in a finally block.\n");
+	exit(1);
+}
+
+/* ---- Lock names must differ between create and remove (per-operation scoping) ---- */
+
+if (!preg_match('/syslog_partition_create\.\'\s*\.\s*\$table/', $functions)) {
+	fwrite(STDERR, "syslog_partition_create lock name does not include function scope.\n");
+	exit(1);
+}
+if (!preg_match('/syslog_partition_remove\.\'\s*\.\s*\$table/', $functions)) {
+	fwrite(STDERR, "syslog_partition_remove lock name does not include function scope.\n");
+	exit(1);
+}
+
+/* ---- syslog_partition_create must return early (no DDL) when allowlist fails ---- */
+
+if (!preg_match('/function\s+syslog_partition_create\s*\(\s*\$table\s*\)\s*\{(.{0,300})/s', $functions, $m_create_guard)) {
+	fwrite(STDERR, "syslog_partition_create function not found.\n");
+	exit(1);
+}
+if (!preg_match('/!syslog_partition_table_allowed[^}]*return\s+false;/s', $m_create_guard[1])) {
+	fwrite(STDERR, "syslog_partition_create does not return early for disallowed tables.\n");
+	exit(1);
+}
+
+/* ---- syslog_partition_check and syslog_partition_remove must use _prepared for info_schema ---- */
+
+if (!preg_match('/function\s+syslog_partition_check\s*\(\s*\$table\s*\)\s*\{(.{0,800})/s', $functions, $m_check_prep)) {
+	fwrite(STDERR, "syslog_partition_check function not found for _prepared check.\n");
+	exit(1);
+}
+if (!preg_match('/syslog_db_fetch_cell_prepared[^)]*information_schema[^)]*table_name\s*=\s*\?/s', $m_check_prep[1])) {
+	fwrite(STDERR, "syslog_partition_check does not use _prepared with table_name placeholder.\n");
+	exit(1);
+}
+
+echo "issue254_partition_table_locking_test passed\n";


### PR DESCRIPTION
## Summary
- scope partition create/check/remove queries to the requested table instead of hardcoded syslog
- add a table allowlist guard for partition maintenance helpers
- serialize partition creation using GET_LOCK/RELEASE_LOCK to avoid concurrent duplicate partition creation
- add regression test for table scoping and lock usage
- update changelog with issue #254

Fixes #254

## Validation
- php -l functions.php
- php -l tests/regression/issue254_partition_table_locking_test.php
- php tests/regression/issue254_partition_table_locking_test.php