### PR TITLE
bugfix: use strict MariaDB detection in install advisor

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -960,10 +960,11 @@ function syslog_install_advisor($syslog_exists) {
 		$type = __('Install', 'syslog');
 	}
 
-	$database = db_fetch_row('SHOW GLOBAL VARIABLES LIKE "version"');
+	syslog_connect();
+	$database = syslog_db_fetch_row('SHOW GLOBAL VARIABLES LIKE "version"');
 
-	/* remove Aria as a storage enging if this is mysql */
-	if (stripos($database['Value'], 'mariadb') == false) {
+	/* remove Aria as a storage engine if this is mysql */
+	if (stripos($database['Value'], 'mariadb') === false) {
 		unset($fields_syslog_update['engine']['array']['aria']);
 	} else {
 		$fields_syslog_update['engine']['value'] = 'aria';
@@ -1626,4 +1627,3 @@ function syslog_utilities_list() {
 	</tr>
 	<?php
 }
-

--- a/tests/regression/issue270_mariadb_detection_strict_test.php
+++ b/tests/regression/issue270_mariadb_detection_strict_test.php
@@ -1,0 +1,23 @@
+<?php
+
+$setup = file_get_contents(dirname(__DIR__, 2) . '/setup.php');
+
+if ($setup === false) {
+	fwrite(STDERR, "Failed to load setup.php\n");
+	exit(1);
+}
+
+$legacyPattern = '/stripos\s*\(\s*\$database\s*\[\s*[\'"]{1}Value[\'"]{1}\s*\]\s*,\s*[\'"]{1}mariadb[\'"]{1}\s*\)\s*==\s*false/';
+$fixedPattern  = '/stripos\s*\(\s*\$database\s*\[\s*[\'"]{1}Value[\'"]{1}\s*\]\s*,\s*[\'"]{1}mariadb[\'"]{1}\s*\)\s*===\s*false/';
+
+if (preg_match($legacyPattern, $setup)) {
+	fwrite(STDERR, "Legacy loose MariaDB stripos comparison is still present.\n");
+	exit(1);
+}
+
+if (!preg_match($fixedPattern, $setup)) {
+	fwrite(STDERR, "Strict MariaDB stripos comparison is missing.\n");
+	exit(1);
+}
+
+echo "issue270_mariadb_detection_strict_test passed\n";


### PR DESCRIPTION
## Summary
- switch MariaDB version detection from loose to strict stripos comparison
- avoid ambiguous falsey handling in upgrade advisor engine selection
- add regression test for strict comparison
- update changelog with issue #270

Fixes #270

## Validation
- php -l setup.php
- php -l tests/regression/issue270_mariadb_detection_strict_test.php
- php tests/regression/issue270_mariadb_detection_strict_test.php