### PR TITLE
hardening: parameterize domain stripping update query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 --- develop ---
 
 * issue#250: Fix date filter persistence by validating before shift_span detection
+* issue#261: Parameterize domain stripping update query in syslog incoming processing
 * issue: Making changes to support Cacti 1.3
 * issue: Don't use MyISAM for non-analytical tables
 * issue: The install advisor for Syslog was broken in current Cacti releases

--- a/functions.php
+++ b/functions.php
@@ -1757,10 +1757,17 @@ function syslog_strip_incoming_domains($uniqueID) {
 		$domains = explode(',', trim($syslog_domains));
 
 		foreach($domains as $domain) {
-			syslog_db_execute('UPDATE `' . $syslogdb_default . "`.`syslog_incoming`
+			$domain = trim($domain);
+
+			if ($domain == '') {
+				continue;
+			}
+
+			syslog_db_execute_prepared('UPDATE `' . $syslogdb_default . '`.`syslog_incoming`
 				SET host = SUBSTRING_INDEX(host, '.', 1)
-				WHERE host LIKE '%$domain'
-				AND `status` = $uniqueID");
+				WHERE host LIKE ?
+				AND `status` = ?',
+				array('%' . $domain, $uniqueID));
 		}
 	}
 }
@@ -2421,4 +2428,3 @@ function alert_replace_variables($alert, $results, $hostname = '') {
 
 	return $command;
 }
-

--- a/tests/regression/issue261_domain_strip_parameterized_test.php
+++ b/tests/regression/issue261_domain_strip_parameterized_test.php
@@ -1,0 +1,27 @@
+<?php
+
+$functions = file_get_contents(dirname(__DIR__, 2) . '/functions.php');
+
+if ($functions === false) {
+	fwrite(STDERR, "Failed to load functions.php\n");
+	exit(1);
+}
+
+if (strpos($functions, "WHERE host LIKE '%\$domain'") !== false) {
+	fwrite(STDERR, "Legacy interpolated domain LIKE clause is still present.\n");
+	exit(1);
+}
+
+if (strpos($functions, 'AND `status` = $uniqueID') !== false) {
+	fwrite(STDERR, "Legacy interpolated status filter is still present.\n");
+	exit(1);
+}
+
+if (strpos($functions, "WHERE host LIKE ?") === false ||
+	strpos($functions, "AND `status` = ?") === false ||
+	strpos($functions, "array('%' . \$domain, \$uniqueID)") === false) {
+	fwrite(STDERR, "Expected parameterized domain strip query is missing.\n");
+	exit(1);
+}
+
+echo "issue261_domain_strip_parameterized_test passed\n";


### PR DESCRIPTION
## Summary
- replace interpolated domain/status SQL in syslog_strip_incoming_domains() with a prepared update query
- skip empty configured domain tokens before executing updates
- add regression test to prevent reintroduction of interpolated query fragments
- update changelog with issue #261

Fixes #261

## Validation
- php -l functions.php
- php -l tests/regression/issue261_domain_strip_parameterized_test.php
- php tests/regression/issue261_domain_strip_parameterized_test.php