### PR TITLE
hardening: remove /bin/sh fallback from alert command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 --- develop ---
 
 * issue#250: Fix date filter persistence by validating before shift_span detection
+* issue#257: Remove /bin/sh fallback from alert command execution path
 * issue: Making changes to support Cacti 1.3
 * issue: Don't use MyISAM for non-analytical tables
 * issue: The install advisor for Syslog was broken in current Cacti releases

--- a/functions.php
+++ b/functions.php
@@ -1521,23 +1521,23 @@ function syslog_process_alert($alert, $sql, $params, $count, $hostname = '') {
 					}
 
 					if (trim($alert['command']) != '' && !$found) {
-						$command = alert_replace_variables($alert, $results, $hostname);
+						$command    = alert_replace_variables($alert, $results, $hostname);
+						$cparts     = preg_split('/\s+/', trim($command));
+						/* trim surrounding quotes so paths like "/usr/bin/cmd" resolve correctly */
+						$executable = trim($cparts[0], '"\'');
+						$output     = array();
+						$returnCode = 0;
 
-						$logMessage = "SYSLOG NOTICE: Executing '$command'";
-
-						$cparts = explode(' ', $command);
-
-						if (is_executable($cparts[0])) {
+						if (cacti_sizeof($cparts) && is_executable($executable)) {
 							exec($command, $output, $returnCode);
+							cacti_log("SYSLOG NOTICE: Executing '$command' Command return code: $returnCode", true, 'SYSTEM');
 						} else {
-							exec('/bin/sh ' . $command, $output, $returnCode);
+							$returnCode = 126;
+							$reason     = (strpos($executable, DIRECTORY_SEPARATOR) === false)
+								? 'PATH-based lookups are not supported; use an absolute path'
+								: 'file not found or not marked executable';
+							cacti_log("SYSLOG ERROR: Alert command is not executable: '$command' -- $reason", false, 'SYSTEM');
 						}
-
-						// Append the return code to the log message without the dot
-						$logMessage .= " Command return code: $returnCode";
-
-						// Log the combined message
-						cacti_log($logMessage, true, 'SYSTEM');
 					}
 
 				}
@@ -1581,23 +1581,23 @@ function syslog_process_alert($alert, $sql, $params, $count, $hostname = '') {
 					}
 
 					if (trim($alert['command']) != '' && !$found) {
-						$command = alert_replace_variables($alert, $results, $hostname);
+						$command    = alert_replace_variables($alert, $results, $hostname);
+						$cparts     = preg_split('/\s+/', trim($command));
+						/* trim surrounding quotes so paths like "/usr/bin/cmd" resolve correctly */
+						$executable = trim($cparts[0], '"\'');
+						$output     = array();
+						$returnCode = 0;
 
-						$logMessage = "SYSLOG NOTICE: Executing '$command'";
-
-						$cparts = explode(' ', $command);
-
-						if (is_executable($cparts[0])) {
+						if (cacti_sizeof($cparts) && is_executable($executable)) {
 							exec($command, $output, $returnCode);
+							cacti_log("SYSLOG NOTICE: Executing '$command' Command return code: $returnCode", true, 'SYSTEM');
 						} else {
-							exec('/bin/sh ' . $command, $output, $returnCode);
+							$returnCode = 126;
+							$reason     = (strpos($executable, DIRECTORY_SEPARATOR) === false)
+								? 'PATH-based lookups are not supported; use an absolute path'
+								: 'file not found or not marked executable';
+							cacti_log("SYSLOG ERROR: Alert command is not executable: '$command' -- $reason", false, 'SYSTEM');
 						}
-
-						// Append the return code to the log message without the dot
-						$logMessage .= " Command return code: $returnCode";
-
-						// Log the combined message
-						cacti_log($logMessage, true, 'SYSTEM');
 					}
 				}
 			}
@@ -2421,4 +2421,3 @@ function alert_replace_variables($alert, $results, $hostname = '') {
 
 	return $command;
 }
-

--- a/tests/regression/issue257_remove_shell_fallback_test.php
+++ b/tests/regression/issue257_remove_shell_fallback_test.php
@@ -1,0 +1,30 @@
+<?php
+
+$functions = file_get_contents(dirname(__DIR__, 2) . '/functions.php');
+
+if ($functions === false) {
+	fwrite(STDERR, "Failed to load functions.php\n");
+	exit(1);
+}
+
+if (strpos($functions, "exec('/bin/sh ' . \$command") !== false) {
+	fwrite(STDERR, "Shell fallback execution path is still present.\n");
+	exit(1);
+}
+
+if (preg_match_all('/\bpreg_split\b/', $functions) < 2) {
+	fwrite(STDERR, "Expected command tokenization update is missing.\n");
+	exit(1);
+}
+
+if (preg_match_all('/\$returnCode\s*=\s*126/', $functions) < 2) {
+	fwrite(STDERR, "Expected non-executable return code handling is missing.\n");
+	exit(1);
+}
+
+if (preg_match_all('/SYSLOG ERROR: Alert command is not executable/', $functions) < 2) {
+	fwrite(STDERR, "Expected non-executable command log message is missing.\n");
+	exit(1);
+}
+
+echo "issue257_remove_shell_fallback_test passed\n";


### PR DESCRIPTION
## Summary
- remove /bin/sh fallback execution path for alert commands
- execute commands only when the first token resolves to an executable file
- log explicit errors and return code 126 for non-executable command targets
- add regression test ensuring shell fallback is not reintroduced
- update changelog with issue #257

Fixes #257

## Validation
- php -l functions.php
- php -l tests/regression/issue257_remove_shell_fallback_test.php
- php tests/regression/issue257_remove_shell_fallback_test.php