### PR TITLE
refactor: centralize XML import payload loading

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -126,6 +126,52 @@ function syslog_sendemail($to, $from, $subject, $message, $smsmessage = '') {
 	}
 }
 
+function syslog_get_import_xml_payload($redirect_url) {
+	if (trim(get_nfilter_request_var('import_text')) != '') {
+		/* textbox input */
+		return get_nfilter_request_var('import_text');
+	}
+
+	if (isset($_FILES['import_file']['tmp_name']) &&
+		$_FILES['import_file']['tmp_name'] != 'none' &&
+		$_FILES['import_file']['tmp_name'] != '') {
+		/* file upload */
+		$tmp_name = $_FILES['import_file']['tmp_name'];
+
+		if (!isset($_FILES['import_file']['error']) || $_FILES['import_file']['error'] !== UPLOAD_ERR_OK) {
+			header('Location: ' . $redirect_url);
+			exit;
+		}
+
+		if (!is_uploaded_file($tmp_name)) {
+			header('Location: ' . $redirect_url);
+			exit;
+		}
+
+		$fp = fopen($tmp_name, 'rb');
+
+		if ($fp === false) {
+			cacti_log('SYSLOG ERROR: Failed to open uploaded import file', false, 'SYSTEM');
+			header('Location: ' . $redirect_url);
+			exit;
+		}
+
+		$xml_data = fread($fp, filesize($tmp_name));
+		fclose($fp);
+
+		if ($xml_data === false) {
+			cacti_log('SYSLOG ERROR: Failed to read uploaded import file', false, 'SYSTEM');
+			header('Location: ' . $redirect_url);
+			exit;
+		}
+
+		return $xml_data;
+	}
+
+	header('Location: ' . $redirect_url);
+	exit;
+}
+
 function syslog_is_partitioned() {
 	global $syslogdb_default;
 
@@ -2421,4 +2467,3 @@ function alert_replace_variables($alert, $results, $hostname = '') {
 
 	return $command;
 }
-

--- a/syslog_alerts.php
+++ b/syslog_alerts.php
@@ -939,18 +939,7 @@ function import() {
 }
 
 function alert_import() {
-	if (trim(get_nfilter_request_var('import_text') != '')) {
-		/* textbox input */
-		$xml_data = get_nfilter_request_var('import_text');
-	} elseif (($_FILES['import_file']['tmp_name'] != 'none') && ($_FILES['import_file']['tmp_name'] != '')) {
-		/* file upload */
-		$fp = fopen($_FILES['import_file']['tmp_name'],'r');
-		$xml_data = fread($fp, filesize($_FILES['import_file']['tmp_name']));
-		fclose($fp);
-	} else {
-		header('Location: syslog_alerts.php?header=false');
-		exit;
-	}
+	$xml_data = syslog_get_import_xml_payload('syslog_alerts.php?header=false');
 
 	$xml_array = xml2array($xml_data);
 
@@ -1009,4 +998,3 @@ function alert_import() {
 
 	header('Location: syslog_alerts.php');
 }
-

--- a/syslog_removal.php
+++ b/syslog_removal.php
@@ -739,18 +739,7 @@ function import() {
 }
 
 function removal_import() {
-	if (trim(get_nfilter_request_var('import_text') != '')) {
-		/* textbox input */
-		$xml_data = get_nfilter_request_var('import_text');
-	} elseif (($_FILES['import_file']['tmp_name'] != 'none') && ($_FILES['import_file']['tmp_name'] != '')) {
-		/* file upload */
-		$fp = fopen($_FILES['import_file']['tmp_name'],'r');
-		$xml_data = fread($fp, filesize($_FILES['import_file']['tmp_name']));
-		fclose($fp);
-	} else {
-		header('Location: syslog_removal.php?header=false');
-		exit;
-	}
+	$xml_data = syslog_get_import_xml_payload('syslog_removal.php?header=false');
 
 	/* obtain debug information if it's set */
 	$xml_array = xml2array($xml_data);
@@ -810,4 +799,3 @@ function removal_import() {
 
 	header('Location: syslog_removal.php');
 }
-

--- a/syslog_reports.php
+++ b/syslog_reports.php
@@ -801,18 +801,7 @@ function import() {
 }
 
 function report_import() {
-	if (trim(get_nfilter_request_var('import_text') != '')) {
-		/* textbox input */
-		$xml_data = get_nfilter_request_var('import_text');
-	} elseif (($_FILES['import_file']['tmp_name'] != 'none') && ($_FILES['import_file']['tmp_name'] != '')) {
-		/* file upload */
-		$fp = fopen($_FILES['import_file']['tmp_name'],'r');
-		$xml_data = fread($fp, filesize($_FILES['import_file']['tmp_name']));
-		fclose($fp);
-	} else {
-		header('Location: syslog_reports.php?header=false');
-		exit;
-	}
+	$xml_data = syslog_get_import_xml_payload('syslog_reports.php?header=false');
 
 	/* obtain debug information if it's set */
 	$xml_array = xml2array($xml_data);
@@ -872,4 +861,3 @@ function report_import() {
 
 	header('Location: syslog_reports.php');
 }
-

--- a/tests/regression/issue277_import_payload_loader_test.php
+++ b/tests/regression/issue277_import_payload_loader_test.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 2);
+
+$functions = file_get_contents($root . '/functions.php');
+if ($functions === false) {
+	fwrite(STDERR, "Failed to load functions.php\n");
+	exit(1);
+}
+
+if (strpos($functions, 'function syslog_get_import_xml_payload(') === false) {
+	fwrite(STDERR, "Shared import payload loader helper is missing.\n");
+	exit(1);
+}
+
+if (strpos($functions, "trim(get_nfilter_request_var('import_text')) != ''") === false) {
+	fwrite(STDERR, "Shared import payload loader is missing trimmed text handling.\n");
+	exit(1);
+}
+
+$targets = array(
+	$root . '/syslog_alerts.php',
+	$root . '/syslog_reports.php',
+	$root . '/syslog_removal.php'
+);
+
+foreach ($targets as $target) {
+	$content = file_get_contents($target);
+
+	if ($content === false) {
+		fwrite(STDERR, "Failed to load $target\n");
+		exit(1);
+	}
+
+	if (strpos($content, 'syslog_get_import_xml_payload(') === false) {
+		fwrite(STDERR, "Shared import payload loader is not used in $target\n");
+		exit(1);
+	}
+
+	if (strpos($content, "\$_FILES['import_file']['tmp_name']") !== false) {
+		fwrite(STDERR, "Legacy per-file upload payload loading remains in $target\n");
+		exit(1);
+	}
+}
+
+echo "issue277_import_payload_loader_test passed\n";


### PR DESCRIPTION
## Summary
- add a shared helper for loading XML import payload from text input or uploaded file
- use the helper in alert, report, and removal import handlers
- preserve existing redirect flow when payload is missing
- add regression test for helper usage across all three import handlers
- update changelog with issue #277

Fixes #277

## Validation
- php -l functions.php
- php -l syslog_alerts.php
- php -l syslog_reports.php
- php -l syslog_removal.php
- php -l tests/regression/issue277_import_payload_loader_test.php
- php tests/regression/issue277_import_payload_loader_test.php