### PR TITLE
fix: remove concatenated uniqueID from host/program alert SQL

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1667,7 +1667,7 @@ function syslog_get_alert_sql(&$alert, $uniqueID) {
 		$sql = 'SELECT *
 			FROM `' . $syslogdb_default . '`.`syslog_incoming`
 			WHERE `' . $syslog_incoming_config['hostField'] . '` = ?
-			AND `status` = ?' . $uniqueID;
+			AND `status` = ?';
 
 		$params[] = $alert['message'];
 		$params[] = $uniqueID;
@@ -1675,7 +1675,7 @@ function syslog_get_alert_sql(&$alert, $uniqueID) {
 		$sql = 'SELECT *
 			FROM `' . $syslogdb_default . '`.`syslog_incoming`
 			WHERE `' . $syslog_incoming_config['programField'] . '` = ?
-			AND `status` = ?' . $uniqueID;
+			AND `status` = ?';
 
 		$params[] = $alert['message'];
 		$params[] = $uniqueID;


### PR DESCRIPTION
## Summary
- Host and program alert type cases in `syslog_get_alert_sql()` appended `$uniqueID` after the `?` placeholder via string concatenation
- This produced invalid SQL like `status = ?12345` instead of `status = ?` with the value bound via `$params[]`
- Removed the concatenation to match the other alert types (facility, messageb, messagec, messagee, sql)

Closes #253

## Test plan
- [ ] Create a host-type alert rule, verify it matches incoming syslog entries
- [ ] Create a program-type alert rule, verify it matches incoming syslog entries
- [ ] Verify facility/message/sql alert types still work unchanged