### PR TITLE
Locales: Portuguese (PT & BR) cleanup and fuzzy resolution

### DIFF
--- a/locales/po/pt-PT.po
+++ b/locales/po/pt-PT.po
@@ -18,27 +18,22 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: functions.php:72
-#, fuzzy
 msgid "Save Failed.  Remote Data Collectors in Sync Mode are not allowed to Save Rules.  Save from the Main Cacti Server instead."
 msgstr "Falha ao salvar. Os coletores de dados remotos no modo de sincronização não têm permissão para salvar regras. Em vez disso, salve no servidor principal do Cacti."
 
 #: functions.php:116
-#, fuzzy
 msgid "Please use an HTML Email Client"
 msgstr "Por favor, use um cliente de e-mail HTML"
 
 #: functions.php:1304
-#, fuzzy, php-format
 msgid "Cacti Syslog Threshold Alert '%s' for Host '%s'"
 msgstr "Cacti Syslog Plugin Threshold Alerta '%s' (Limiar de alerta)"
 
 #: functions.php:1306
-#, fuzzy, php-format
 msgid "Cacti Syslog Threshold Alert '%s'"
 msgstr "Cacti Syslog Plugin Threshold Alerta '%s' (Limiar de alerta)"
 
 #: functions.php:1314 syslog.php:1896 syslog_alerts.php:874
-#, fuzzy
 msgid "Alert Name"
 msgstr "Nome do alerta"
 
@@ -49,7 +44,6 @@ msgstr "Gravidade"
 
 #: functions.php:1316 syslog_alerts.php:517 syslog_alerts.php:522
 #: syslog_alerts.php:901
-#, fuzzy
 msgid "Threshold"
 msgstr "Limiar"
 
@@ -58,17 +52,14 @@ msgid "Count"
 msgstr "Contagem"
 
 #: functions.php:1318
-#, fuzzy
 msgid "Match String"
 msgstr "Corda de Correspondência"
 
 #: functions.php:1329 functions.php:1368
-#, fuzzy, php-format
 msgid "Cacti Syslog Alert '%s' for Host '%s'"
 msgstr "Cacti Syslog Plugin Threshold Alerta '%s' (Limiar de alerta)"
 
 #: functions.php:1331 functions.php:1370
-#, fuzzy, php-format
 msgid "Cacti Syslog Alert '%s'"
 msgstr "Cacti Syslog Plugin Alerta de alerta '%s"
 
@@ -91,12 +82,10 @@ msgid "Message"
 msgstr "Mensagem"
 
 #: functions.php:1351
-#, fuzzy, php-format
 msgid "WARNING: A Syslog Threshold Alert has Been Triggered for Host '%s'"
 msgstr "AVISO: Um alerta de contagem de instâncias de plugins do Syslog foi acionado"
 
 #: functions.php:1353
-#, fuzzy
 msgid "WARNING: A Syslog Threshold Alert has Been Triggered"
 msgstr "AVISO: Um alerta de contagem de instâncias de plugins do Syslog foi acionado"
 
@@ -105,12 +94,10 @@ msgid "Name:"
 msgstr "Nome:"
 
 #: functions.php:1361 functions.php:1417
-#, fuzzy
 msgid "Severity:"
 msgstr "Gravidade"
 
 #: functions.php:1362
-#, fuzzy
 msgid "Threshold:"
 msgstr "Limiar:"
 
@@ -119,7 +106,6 @@ msgid "Count:"
 msgstr "Contagem:"
 
 #: functions.php:1364
-#, fuzzy
 msgid "Message String:"
 msgstr "Cadeia de mensagens:"
 
@@ -140,27 +126,22 @@ msgid "Message:"
 msgstr "Mensagem:"
 
 #: functions.php:1484
-#, fuzzy
 msgid ", Host:"
 msgstr "Servidor:"
 
 #: functions.php:1484 functions.php:1548
-#, fuzzy
 msgid ", URL:"
 msgstr "URL:"
 
 #: functions.php:1484 functions.php:1548
-#, fuzzy
 msgid "Sev:"
 msgstr "Sev:"
 
 #: functions.php:1490 functions.php:1544
-#, fuzzy, php-format
 msgid "Event Alert - %s"
 msgstr "Alerta de Evento - %s"
 
 #: functions.php:1548
-#, fuzzy
 msgid ", Count:"
 msgstr "Contagem:"
 
@@ -169,47 +150,38 @@ msgid "Host"
 msgstr "Hospedeiro"
 
 #: functions.php:2116
-#, fuzzy, php-format
 msgid "Event Report - %s"
 msgstr "Relatório de eventos - %s"
 
 #: setup.php:34
-#, fuzzy
 msgid "Please rename either your config.php.dist or config_local.php.dist files in the syslog directory, and change setup your database before installing."
 msgstr "Por favor, renomeie seu arquivo config.php.dist no diretório syslog e altere a configuração do banco de dados antes de instalar."
 
 #: setup.php:274
-#, fuzzy
 msgid "Syslog 2.0 Requires an Entire Reinstall.  Please uninstall Syslog and Remove all Data before Installing.  Migration is possible, but you must plan this in advance.  No automatic migration is supported."
 msgstr "O Syslog 2.0 requer uma reinstalação completa.  Desinstale o Syslog e remova todos os dados antes de instalar.  A migração é possível, mas você deve planejar isso com antecedência.  Nenhuma migração automática é suportada."
 
 #: setup.php:862
-#, fuzzy
 msgid "What upgrade/install type do you wish to use"
 msgstr "Que tipo de atualização/instalação você deseja usar"
 
 #: setup.php:863
-#, fuzzy
 msgid "When you have very large tables, performing a Truncate will be much quicker.  If you are concerned about archive data, you can choose either Inline, which will freeze your browser for the period of this upgrade, or background, which will create a background process to bring your old syslog data from a backup table to the new syslog format.  Again this process can take several hours."
 msgstr "Quando você tem tabelas muito grandes, executar um Truncado será muito mais rápido.  Se está preocupado com dados de arquivo, pode escolher Inline, que irá congelar o seu browser durante o período desta actualização, ou background, que irá criar um processo de background para trazer os seus dados antigos do syslog de uma tabela de backup para o novo formato syslog.  Mais uma vez, este processo pode demorar várias horas."
 
 #: setup.php:866
-#, fuzzy
 msgid "Truncate Syslog Table"
 msgstr "Truncar a tabela Syslog"
 
 #: setup.php:867
-#, fuzzy
 msgid "Inline Upgrade"
 msgstr "Upgrade Inline"
 
 #: setup.php:868
-#, fuzzy
 msgid "Background Upgrade"
 msgstr "Atualização de plano de fundo"
 
 #: setup.php:873
-#, fuzzy
 msgid "Database Storage Engine"
 msgstr "Mecanismo de armazenamento de banco de dados"
 
@@ -218,57 +190,46 @@ msgid "You have the option to make this a partitioned table by days."
 msgstr ""
 
 #: setup.php:877
-#, fuzzy
 msgid "MyISAM Storage"
 msgstr "Armazenamento MyISAM"
 
 #: setup.php:878
-#, fuzzy
 msgid "InnoDB Storage"
 msgstr "Armazenamento InnoDB"
 
 #: setup.php:883
-#, fuzzy
 msgid "Database Architecture"
 msgstr "Arquitetura de banco de dados"
 
 #: setup.php:884
-#, fuzzy
 msgid "You have the option to make this a partitioned table by days.  You can create multiple partitions per day."
 msgstr "No MySQL 5.1.6 e acima, você tem a opção de fazer disso uma tabela particionada por dias.  Antes deste release, só havia a estrutura de tabela tradicional disponível."
 
 #: setup.php:887
-#, fuzzy
 msgid "Traditional Table"
 msgstr "Mesa Tradicional"
 
 #: setup.php:888
-#, fuzzy
 msgid "Partitioned Table"
 msgstr "Mesa Particionada"
 
 #: setup.php:893
-#, fuzzy
 msgid "Retention Policy"
 msgstr "Política de Retenção de Sócios"
 
 #: setup.php:894
-#, fuzzy
 msgid "Choose how many days of Syslog values you wish to maintain in the database."
 msgstr "Escolha quantos dias de valores Syslog você deseja manter no banco de dados."
 
 #: setup.php:914
-#, fuzzy
 msgid "Partitions per Day"
 msgstr "Partições por dia"
 
 #: setup.php:915
-#, fuzzy
 msgid "Select the number of partitions per day that you wish to create."
 msgstr "Selecione o número de partições por dia que deseja criar."
 
 #: setup.php:918 setup.php:919 setup.php:920 setup.php:921 setup.php:922
-#, fuzzy, php-format
 msgid "%d Per Day"
 msgstr "%d Por Dia"
 
@@ -281,62 +242,50 @@ msgid "Install"
 msgstr "Instalar"
 
 #: setup.php:933
-#, fuzzy, php-format
 msgid "Syslog %s Advisor"
 msgstr "Syslog %s Advisor"
 
 #: setup.php:937
-#, fuzzy
 msgid "WARNING: Syslog Upgrade is Time Consuming!!!"
 msgstr "AVISO: A atualização do Syslog consome muito tempo!!!!!"
 
 #: setup.php:938
-#, fuzzy
 msgid "The upgrade of the 'main' syslog table can be a very time consuming process.  As such, it is recommended that you either reduce the size of your syslog table prior to upgrading, or choose the background option</p> <p>If you choose the background option, your legacy syslog table will be renamed, and a new syslog table will be created.  Then, an upgrade process will be launched in the background.  Again, this background process can quite a bit of time to complete.  However, your data will be preserved</p> <p>Regardless of your choice, all existing removal and alert rules will be maintained during the upgrade process.</p> <p>Press <b>'Upgrade'</b> to proceed with the upgrade, or <b>'Cancel'</b> to return to the Plugins menu."
 msgstr "A actualização da tabela syslog 'main' pode ser um processo muito demorado.  Como tal, recomenda-se que você reduza o tamanho da tabela de syslog antes da atualização ou escolha a opção de fundo</p> <p>Se você escolher a opção de fundo, sua tabela de syslog legada será renomeada e uma nova tabela de syslog será criada.  Então, um processo de atualização será iniciado em segundo plano.  Mais uma vez, este processo de fundo pode demorar bastante tempo para ser concluído.  No entanto, seus dados serão preservados</p> <p> Independentemente da sua escolha, todas as regras de remoção e alerta existentes serão mantidas durante o processo de upgrade.</p> <p>Press <b>'Upgrade'</b> para prosseguir com o upgrade, ou <b>'Cancel'</b> para retornar ao menu Plugins."
 
 #: setup.php:941
-#, fuzzy
 msgid "You can also select the retention duration.  Please keep in mind that if you have several hosts logging to syslog, this table can become quite large.  So, if not using partitioning, you might want to keep the size smaller."
 msgstr "Também é possível selecionar a duração da retenção.  Por favor tenha em mente que se tiver várias máquinas a iniciar sessão no syslog, esta tabela pode tornar-se bastante grande.  Então, se não estiver usando particionamento, você pode querer manter o tamanho menor."
 
 #: setup.php:941
-#, fuzzy
 msgid "You can also set the MySQL storage engine.  If you have not tuned you system for InnoDB storage properties, it is strongly recommended that you utilize the MyISAM storage engine."
 msgstr "Você também pode definir o mecanismo de armazenamento MySQL.  Se você não tiver ajustado seu sistema para propriedades de armazenamento InnoDB, é altamente recomendável que você utilize o mecanismo de armazenamento MyISAM."
 
 #: setup.php:941
-#, fuzzy
 msgid "You have several options to choose from when installing Syslog.  The first is the Database Architecture.  You should elect to utilize Table Partitioning to prevent the size of the tables from becoming excessive thus slowing queries."
 msgstr "Você tem várias opções para escolher ao instalar o Syslog.  A primeira é a Arquitectura de Base de Dados.  A partir do MySQL 5.1.6, você pode optar por utilizar o Particionamento de Tabelas para evitar que o tamanho das tabelas se torne excessivo, diminuindo assim a velocidade das consultas."
 
 #: setup.php:945
-#, fuzzy, php-format
 msgid "Syslog %s Settings"
 msgstr "Syslog %s Configurações"
 
 #: setup.php:972
-#, fuzzy
 msgid "What uninstall method do you want to use?"
 msgstr "Qual método de desinstalação você deseja usar?"
 
 #: setup.php:973
-#, fuzzy
 msgid "When uninstalling syslog, you can remove everything, or only components, just in case you plan on re-installing in the future."
 msgstr "Ao desinstalar o syslog, você pode remover tudo, ou apenas componentes, caso planeje reinstalar no futuro."
 
 #: setup.php:975
-#, fuzzy
 msgid "Remove Everything (Logs, Tables, Settings)"
 msgstr "Remover Tudo (Logs, Tabelas, Configurações)"
 
 #: setup.php:975
-#, fuzzy
 msgid "Syslog Data Only"
 msgstr "Somente dados Syslog"
 
 #: setup.php:995
-#, fuzzy
 msgid "Syslog Uninstall Preferences"
 msgstr "Preferências de desinstalação do Syslog"
 
@@ -350,7 +299,6 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: setup.php:1066 setup.php:1202 setup.php:1204 setup.php:1410 setup.php:1424
-#, fuzzy
 msgid "Syslog"
 msgstr "Syslog"
 
@@ -359,42 +307,34 @@ msgid "General Settings"
 msgstr "Configurações Gerais"
 
 #: setup.php:1074
-#, fuzzy
 msgid "Syslog Enabled"
 msgstr "Syslog habilitado"
 
 #: setup.php:1075
-#, fuzzy
 msgid "If this checkbox is set, records will be transferred from the Syslog Incoming table to the main syslog table and Alerts and Reports will be enabled.  Please keep in mind that if the system is disabled log entries will still accumulate into the Syslog Incoming table as this is defined by the rsyslog or syslog-ng process."
 msgstr "Se essa caixa de seleção estiver definida, os registros serão transferidos da tabela Syslog Incoming para a tabela principal do syslog e Alertas e relatórios serão ativados.  Tenha em mente que, se o sistema estiver desativado, as entradas de log ainda se acumularão na tabela Syslog Incoming, pois isso é definido pelo processo rsyslog ou syslog-ng."
 
 #: setup.php:1080
-#, fuzzy
 msgid "Enable Statistics Gathering"
 msgstr "Ativar a coleta de estatísticas"
 
 #: setup.php:1081
-#, fuzzy
 msgid "If this checkbox is set, statistics on where syslog messages are arriving from will be maintained.  This statistical information can be used to render things such as heat maps."
 msgstr "Se esta opção estiver definida, as estatísticas de onde as mensagens do syslog estão a chegar serão mantidas.  Esta informação estatística pode ser usada para renderizar coisas como mapas de calor."
 
 #: setup.php:1086
-#, fuzzy
 msgid "Strip Domains"
 msgstr "Domínios de Strip"
 
 #: setup.php:1087
-#, fuzzy
 msgid "A comma delimited list of domains that you wish to remove from the syslog hostname, Examples would be 'mydomain.com, otherdomain.com'"
 msgstr "Uma lista delimitada por vírgula de domínios que você deseja remover do hostname syslog, Exemplos seriam 'mydomain.com, otherdomain.com'."
 
 #: setup.php:1094
-#, fuzzy
 msgid "Validate Hostnames"
 msgstr "Validar nomes de host"
 
 #: setup.php:1095
-#, fuzzy
 msgid "If this checkbox is set, all hostnames are validated.  If the hostname is not valid. All records are assigned to a special host called 'invalidhost'.  This setting can impact syslog processing time on large systems.  Therefore, use of this setting should only be used when other means are not in place to prevent this from happening."
 msgstr "Se essa caixa de seleção estiver definida, todos os nomes de host serão validados.  Se o hostname não for válido. Todos os registros são atribuídos a uma máquina especial chamada 'invalidhost'.  Essa configuração pode afetar o tempo de processamento do syslog em sistemas grandes.  Por conseguinte, a utilização desta definição só deve ser utilizada quando não existirem outros meios para evitar que tal aconteça."
 
@@ -403,108 +343,87 @@ msgid "Refresh Interval"
 msgstr "Intervalo de Atualização"
 
 #: setup.php:1101
-#, fuzzy
 msgid "This is the time in seconds before the page refreshes."
 msgstr "Este é o tempo em segundos antes da atualização da página."
 
 #: setup.php:1107
-#, fuzzy
 msgid "Max Report Records"
 msgstr "Registros máximos de relatórios"
 
 #: setup.php:1108
-#, fuzzy
 msgid "For Threshold based Alerts, what is the maximum number that you wish to show in the report.  This is used to limit the size of the html log and Email."
 msgstr "Para Alertas baseados em Limiares, qual é o número máximo que você deseja mostrar no relatório.  Isto é usado para limitar o tamanho do registo html e do e-mail."
 
 #: setup.php:1112 setup.php:1113 setup.php:1114 setup.php:1115 setup.php:1116
 #: setup.php:1117
-#, fuzzy, php-format
 msgid "%d Records"
 msgstr "Registros %d"
 
 #: setup.php:1121
-#, fuzzy
 msgid "Command for Opening Tickets"
 msgstr "Comando de abertura de bilhetes"
 
 #: setup.php:1122
-#, fuzzy
 msgid "This command will be executed for opening Help Desk Tickets.  The command will be required to parse multiple input parameters as follows: <b>--alert-name</b>, <b>--severity</b>, <b>--hostlist</b>, <b>--message</b>.  The hostlist will be a comma delimited list of hosts impacted by the alert."
 msgstr "Este comando será executado para abrir Help Desk Tickets.  O comando será necessário para analisar vários parâmetros de entrada da seguinte forma: <b>--Nome do comerciante</b>, <b>--severidade</b>, <b>--lista de hospedeiros</b>, <b>--mensagem</b>.  A hostlist será uma lista delimitada por vírgulas de hosts afetados pelo alerta."
 
 #: setup.php:1128
-#, fuzzy
 msgid "HTML Notification Settings"
 msgstr "Lista de Notificações"
 
 #: setup.php:1133
-#, fuzzy
 msgid "Enable HTML Based Email"
 msgstr "E-mail baseado em HTML"
 
 #: setup.php:1134
-#, fuzzy
 msgid "If this checkbox is set, all Emails will be sent in HTML format.  Otherwise, Emails will be sent in plain text."
 msgstr "Se esta opção estiver definida, todos os e-mails serão enviados em formato HTML.  Caso contrário, os e-mails serão enviados em texto simples."
 
 #: setup.php:1139
-#, fuzzy
 msgid "Format File to Use"
 msgstr "Utilizador normal"
 
 #: setup.php:1142
-#, fuzzy
 msgid "Choose the custom html wrapper and CSS file to use.  This file contains both html and CSS to wrap around your report.  If it contains more than simply CSS, you need to place a special <REPORT> tag inside of the file.  This format tag will be replaced by the report content.  These files are located in the 'formats' directory."
 msgstr "Escolha o wrapper html personalizado e o arquivo CSS a ser usado. Este arquivo contém html e CSS para envolver seu relatório. Se ele contém mais do que simplesmente CSS, você precisa colocar um<REPORT> tag dentro do arquivo. Essa tag de formato será substituída pelo conteúdo do relatório. Esses arquivos estão localizados no diretório 'formatos'."
 
 #: setup.php:1146
-#, fuzzy
 msgid "Data Retention Settings"
 msgstr "Configurações de retenção de dados"
 
 #: setup.php:1151
-#, fuzzy
 msgid "Syslog Retention"
 msgstr "Retenção Syslog"
 
 #: setup.php:1152
-#, fuzzy
 msgid "This is the number of days to keep events."
 msgstr "Este é o número de dias para manter os eventos."
 
 #: setup.php:1158
-#, fuzzy
 msgid "Syslog Alert Retention"
 msgstr "Retenção de Alerta Syslog"
 
 #: setup.php:1159
-#, fuzzy
 msgid "This is the number of days to keep alert logs."
 msgstr "Este é o número de dias para manter registos de alerta."
 
 #: setup.php:1165
-#, fuzzy
 msgid "Remote Message Processing"
 msgstr "Cadeia de mensagens:"
 
 #: setup.php:1169
-#, fuzzy
 msgid "Enable Remote Data Collector Message Processing"
 msgstr "Ativar processamento de mensagens do coletor de dados remoto"
 
 #: setup.php:1170
-#, fuzzy
 msgid "If your Remote Data Collectors have their own Syslog databases and process their messages independently, check this checkbox.  By checking this Checkbox, your Remote Data Collectors will need to maintain their own 'config_local.php' file in order to inform Syslog to use an independent database for message display and processing.  Please use the template file 'config_local.php.dist' for this purpose.  WARNING: Syslog tables will be automatically created as soon as this option is enabled."
 msgstr "Se seus Coletores de Dados Remotos tiverem seus próprios bancos de dados Syslog e processarem suas mensagens de forma independente, marque esta caixa de seleção. Ao marcar esta caixa de seleção, seus coletores de dados remotos precisarão manter seu próprio arquivo 'config_local.php' para informar ao Syslog para usar um banco de dados independente para exibição e processamento de mensagens. Por favor, use o arquivo de modelo 'config_local.php.dist' para este propósito. AVISO: As tabelas Syslog serão criadas automaticamente assim que esta opção for habilitada."
 
 #: setup.php:1175
-#, fuzzy
 msgid "Remote Data Collector Rules Sync"
 msgstr "Sincronização de regras do coletor de dados remoto"
 
 #: setup.php:1176
-#, fuzzy
 msgid "If your Remote Data Collectors have their own Syslog databases and process thrie messages independently, check this checkbox if you wish the Main Cacti databases Alerts, Removal and Report rules to be sent to the Remote Cacti System."
 msgstr "Se seus coletores de dados remotos tiverem seus próprios bancos de dados Syslog e processarem três mensagens de forma independente, marque esta caixa de seleção se desejar que as regras de alertas, remoção e relatórios dos bancos de dados principais do Cacti sejam enviadas para o sistema Remote Cacti."
 
@@ -525,12 +444,10 @@ msgid "Export"
 msgstr "Exportar"
 
 #: setup.php:1295 setup.php:1314
-#, fuzzy
 msgid "Indefinite"
 msgstr "Indefinido"
 
 #: setup.php:1296 setup.php:1315 syslog.php:608 syslog_alerts.php:409
-#, fuzzy, php-format
 msgid "%d Day"
 msgstr "%d Dia"
 
@@ -542,28 +459,23 @@ msgid "%d Days"
 msgstr "%d Dias"
 
 #: setup.php:1302 setup.php:1321 syslog_alerts.php:411
-#, fuzzy, php-format
 msgid "%d Week"
 msgstr "%d Semana"
 
 #: setup.php:1303 setup.php:1322 syslog_alerts.php:412
-#, fuzzy, php-format
 msgid "%d Weeks"
 msgstr "%d Semanas"
 
 #: setup.php:1304 setup.php:1323
-#, fuzzy, php-format
 msgid "%d Month"
 msgstr "%d Mês"
 
 #: setup.php:1305 setup.php:1306 setup.php:1307 setup.php:1308 setup.php:1309
 #: setup.php:1324 setup.php:1325 setup.php:1326 setup.php:1327 setup.php:1328
-#, fuzzy, php-format
 msgid "%d Months"
 msgstr "Meses"
 
 #: setup.php:1310 setup.php:1329
-#, fuzzy, php-format
 msgid "%d Year"
 msgstr "%d Ano"
 
@@ -572,7 +484,6 @@ msgid "Never"
 msgstr "Nunca"
 
 #: setup.php:1334 syslog.php:599
-#, fuzzy, php-format
 msgid "%d Minute"
 msgstr "%d Minuto"
 
@@ -580,7 +491,6 @@ msgstr "%d Minuto"
 #: syslog.php:602 syslog.php:603 syslog_alerts.php:396 syslog_alerts.php:397
 #: syslog_alerts.php:398 syslog_alerts.php:399 syslog_alerts.php:400
 #: syslog_alerts.php:401
-#, fuzzy, php-format
 msgid "%d Minutes"
 msgstr "%d minutos"
 
@@ -597,7 +507,6 @@ msgid "Critical"
 msgstr "Crítico"
 
 #: setup.php:1347
-#, fuzzy
 msgid "Begins with"
 msgstr "A hora de verão começa em: %s."
 
@@ -606,27 +515,22 @@ msgid "Contains"
 msgstr "Contém"
 
 #: setup.php:1349
-#, fuzzy
 msgid "Ends with"
 msgstr "acaba com"
 
 #: setup.php:1350
-#, fuzzy
 msgid "Hostname is"
 msgstr "Nome do servidor:"
 
 #: setup.php:1351
-#, fuzzy
 msgid "Program is"
 msgstr "Programação"
 
 #: setup.php:1352
-#, fuzzy
 msgid "Facility is"
 msgstr "Instalação"
 
 #: setup.php:1353
-#, fuzzy
 msgid "SQL Expression"
 msgstr "Expressão SQL"
 
@@ -643,22 +547,18 @@ msgid "Import/Export"
 msgstr "Importar/Exportar"
 
 #: setup.php:1383
-#, fuzzy
 msgid "Alert Rules"
 msgstr "Regras de alerta"
 
 #: setup.php:1383 setup.php:1384 setup.php:1385 setup.php:1390
-#, fuzzy
 msgid "Syslog Settings"
 msgstr "Configurações do Syslog"
 
 #: setup.php:1384
-#, fuzzy
 msgid "Removal Rules"
 msgstr "Regras de remoção"
 
 #: setup.php:1385
-#, fuzzy
 msgid "Report Rules"
 msgstr "Regras do relatório"
 
@@ -671,7 +571,6 @@ msgid "System Administration"
 msgstr "Administrador de sistemas"
 
 #: setup.php:1411
-#, fuzzy
 msgid "Syslog Removals"
 msgstr "Remoção de Syslogs"
 
@@ -680,58 +579,47 @@ msgid "(Edit)"
 msgstr "(Editar)"
 
 #: setup.php:1414 setup.php:1419 setup.php:1423
-#, fuzzy
 msgid "(Actions)"
 msgstr "Acções"
 
 #: setup.php:1416
-#, fuzzy
 msgid "Syslog Alerts"
 msgstr "Alertas Syslog"
 
 #: setup.php:1421
-#, fuzzy
 msgid "Syslog Reports"
 msgstr "Relatórios Syslog"
 
 #: setup.php:1500
-#, fuzzy
 msgid "Display Syslog in Range"
 msgstr "Mostrar Syslog no intervalo"
 
 #: setup.php:1548
-#, fuzzy, php-format
 msgid "There were %s Device records removed from the Syslog database"
 msgstr "Houve %s Registros de dispositivos removidos do banco de dados do Syslog"
 
 #: setup.php:1564
-#, fuzzy
 msgid "Syslog Utilities"
 msgstr "Utilitários Syslog"
 
 #: setup.php:1568
-#, fuzzy
 msgid "Purge Syslog Devices"
 msgstr "Purgar Dispositivos Syslog"
 
 #: setup.php:1571
-#, fuzzy
 msgid "This menu pick provides a means to remove Devices that are no longer reporting into Cacti's syslog server."
 msgstr "Este menu fornece um meio de remover Dispositivos que não estão mais relatando no servidor syslog do Cacti."
 
 #: syslog.php:58
-#, fuzzy
 msgid "Syslog Viewer"
 msgstr "Visualizador Syslog"
 
 #: syslog.php:61
-#, fuzzy
 msgid "All Text"
 msgstr "Todo o texto"
 
 #: syslog.php:62 syslog.php:63 syslog.php:64 syslog.php:65 syslog.php:66
 #: syslog.php:67
-#, fuzzy, php-format
 msgid "%d Chars"
 msgstr "%d Chars"
 
@@ -744,22 +632,18 @@ msgid "Statistics"
 msgstr "Estatísticas"
 
 #: syslog.php:175
-#, fuzzy
 msgid "Alert Logs"
 msgstr "Registos de alerta"
 
 #: syslog.php:184
-#, fuzzy
 msgid "Selected Alert"
 msgstr "Alerta Selecionado"
 
 #: syslog.php:207
-#, fuzzy
 msgid "Syslog Alert View"
 msgstr "Vista de Alerta do Syslog"
 
 #: syslog.php:288
-#, fuzzy
 msgid "Syslog Statistics Filter"
 msgstr "Filtro de estatísticas do Syslog"
 
@@ -782,7 +666,6 @@ msgid "Priority"
 msgstr "Prioridade"
 
 #: syslog.php:337 syslog.php:1794 syslog.php:1802 syslog.php:1995
-#, fuzzy
 msgid "Program"
 msgstr "Programação"
 
@@ -791,7 +674,6 @@ msgid "Records"
 msgstr "Registros"
 
 #: syslog.php:384
-#, fuzzy
 msgid "No Syslog Statistics Found"
 msgstr "Nenhuma estatística Syslog encontrada"
 
@@ -830,14 +712,12 @@ msgid "Time Range"
 msgstr "Intervalo temporal"
 
 #: syslog.php:604 syslog_alerts.php:402
-#, fuzzy, php-format
 msgid "%d Hour"
 msgstr "%d hora"
 
 #: syslog.php:605 syslog.php:606 syslog.php:607 syslog_alerts.php:403
 #: syslog_alerts.php:404 syslog_alerts.php:405 syslog_alerts.php:406
 #: syslog_alerts.php:407 syslog_alerts.php:408
-#, fuzzy, php-format
 msgid "%d Hours"
 msgstr "%d horas"
 
@@ -851,12 +731,10 @@ msgid "Default"
 msgstr "Padrão"
 
 #: syslog.php:1066
-#, fuzzy, php-format
 msgid " [ Start: '%s' to End: '%s', Unprocessed Messages: %s ]"
 msgstr " Início: '%s' para Fim: '%s', Mensagens não processadas: %s ]"
 
 #: syslog.php:1068
-#, fuzzy, php-format
 msgid "[ Unprocessed Messages: %s ]"
 msgstr "[ Mensagens não processadas: %s ]"
 
@@ -865,22 +743,18 @@ msgid "Enter a search term"
 msgstr "Introduza o termo a pesquisar"
 
 #: syslog.php:1090
-#, fuzzy
 msgid "Select Device(s)"
 msgstr "Selecionar Dispositivo(s)"
 
 #: syslog.php:1092
-#, fuzzy
 msgid "Devices Selected"
 msgstr "Dispositivos selecionados"
 
 #: syslog.php:1095
-#, fuzzy
 msgid "All Devices Selected"
 msgstr "Todos os dispositivos selecionados"
 
 #: syslog.php:1329
-#, fuzzy, php-format
 msgid "Syslog Message Filter %s"
 msgstr "Filtro de mensagens Syslog %s"
 
@@ -897,7 +771,6 @@ msgid "From"
 msgstr "De"
 
 #: syslog.php:1370
-#, fuzzy
 msgid "Start Date Selector"
 msgstr "Seletor de data de início"
 
@@ -906,32 +779,26 @@ msgid "To"
 msgstr "Para"
 
 #: syslog.php:1379
-#, fuzzy
 msgid "End Date Selector"
 msgstr "Seletor de data final"
 
 #: syslog.php:1382
-#, fuzzy
 msgid "Shift Time Backward"
 msgstr "Tempo de turnos para trás"
 
 #: syslog.php:1385
-#, fuzzy
 msgid "Define Shifting Interval"
 msgstr "Definir intervalo de turnos"
 
 #: syslog.php:1398
-#, fuzzy
 msgid "Shift Time Forward"
 msgstr "Shift Time Forward"
 
 #: syslog.php:1403
-#, fuzzy
 msgid "Return filter values to their user defined defaults"
 msgstr "Retornar valores de filtro para seus padrões definidos pelo usuário"
 
 #: syslog.php:1404
-#, fuzzy
 msgid "Export Records to CSV"
 msgstr "Exportar registros para CSV"
 
@@ -940,7 +807,6 @@ msgid "Save"
 msgstr "Guardar"
 
 #: syslog.php:1405
-#, fuzzy
 msgid "Save Default Settings"
 msgstr "Salvar configurações padrão"
 
@@ -949,17 +815,14 @@ msgid "Alerts"
 msgstr "Alertas"
 
 #: syslog.php:1411
-#, fuzzy
 msgid "View Syslog Alert Rules"
 msgstr "Exibir regras de alerta do Syslog"
 
 #: syslog.php:1412
-#, fuzzy
 msgid "Removals"
 msgstr "Remoções"
 
 #: syslog.php:1412
-#, fuzzy
 msgid "View Syslog Removal Rules"
 msgstr "Ver Regras de Remoção do Syslog"
 
@@ -968,7 +831,6 @@ msgid "Reports"
 msgstr "Relatórios"
 
 #: syslog.php:1413
-#, fuzzy
 msgid "View Syslog Reports"
 msgstr "Ver Relatórios Syslog"
 
@@ -977,22 +839,18 @@ msgid "Devices"
 msgstr "Dispositivos"
 
 #: syslog.php:1441
-#, fuzzy
 msgid "Show All Devices"
 msgstr "Mostrar todos os dispositivos"
 
 #: syslog.php:1443
-#, fuzzy
 msgid "Show All Logs"
 msgstr "Mostrar todos os registos"
 
 #: syslog.php:1444
-#, fuzzy
 msgid "Threshold Logs"
 msgstr "Logs de limiar"
 
 #: syslog.php:1553
-#, fuzzy
 msgid "Display Rows"
 msgstr "Exibir linhas"
 
@@ -1001,7 +859,6 @@ msgid "Trim"
 msgstr "Versão"
 
 #: syslog.php:1566
-#, fuzzy
 msgid "Message Trim"
 msgstr "Aparar Mensagem"
 
@@ -1010,7 +867,6 @@ msgid "Refresh"
 msgstr "Atualizar"
 
 #: syslog.php:1596
-#, fuzzy
 msgid "Facilities to filter on"
 msgstr "Facilidades para filtrar"
 
@@ -1019,12 +875,10 @@ msgid "All Facilities"
 msgstr "Todas as Instalações"
 
 #: syslog.php:1618
-#, fuzzy
 msgid "Priority Levels"
 msgstr "Níveis de prioridade"
 
 #: syslog.php:1619
-#, fuzzy
 msgid "All Priorities"
 msgstr "Todas as Prioridades"
 
@@ -1033,7 +887,6 @@ msgid "Emergency"
 msgstr "Emergência"
 
 #: syslog.php:1621
-#, fuzzy
 msgid "Alert++"
 msgstr "Alerta"
 
@@ -1042,12 +895,10 @@ msgid "Alert"
 msgstr "Alerta"
 
 #: syslog.php:1623
-#, fuzzy
 msgid "Critical++"
 msgstr "Crítico"
 
 #: syslog.php:1625
-#, fuzzy
 msgid "Error++"
 msgstr "Erro:"
 
@@ -1056,17 +907,14 @@ msgid "Error"
 msgstr "Erro"
 
 #: syslog.php:1627
-#, fuzzy
 msgid "Warning++"
 msgstr "ADVERTÊNCIA:"
 
 #: syslog.php:1629
-#, fuzzy
 msgid "Notice++"
 msgstr "Aviso"
 
 #: syslog.php:1631
-#, fuzzy
 msgid "Info++"
 msgstr "Informação"
 
@@ -1079,27 +927,22 @@ msgid "Debug"
 msgstr "Saída de depuração personalizada"
 
 #: syslog.php:1638
-#, fuzzy
 msgid "Record Type"
 msgstr "Registros"
 
 #: syslog.php:1641
-#, fuzzy
 msgid "Removal Handling"
 msgstr "Manuseio de Remoção"
 
 #: syslog.php:1642
-#, fuzzy
 msgid "All Records"
 msgstr "Todos os Registros"
 
 #: syslog.php:1643
-#, fuzzy
 msgid "Main Records"
 msgstr "Registros principais"
 
 #: syslog.php:1644
-#, fuzzy
 msgid "Removed Records"
 msgstr "Registros Removidos"
 
@@ -1116,67 +959,54 @@ msgid "Unknown"
 msgstr "Desconhecido"
 
 #: syslog.php:1860
-#, fuzzy
 msgid "No Syslog Messages"
 msgstr "Sem mensagens Syslog"
 
 #: syslog.php:1906
-#, fuzzy
 msgid "Alert Log Rows"
 msgstr "Linhas de log de alerta"
 
 #: syslog.php:1920
-#, fuzzy
 msgid "Alert Removed"
 msgstr "Alerta Removido"
 
 #: syslog.php:1934
-#, fuzzy
 msgid "No Alert Log Messages"
 msgstr "Sem Mensagens de Registo de Alertas"
 
 #: syslog.php:1991 syslog.php:2014 syslog.php:2033 syslog.php:2034
-#, fuzzy
 msgid "All Programs"
 msgstr "Todos os programas"
 
 #: syslog_alerts.php:169
-#, fuzzy
 msgid "Click 'Continue' to Delete the following Syslog Alert Rule(s)."
 msgstr "Clique em 'Continuar' para excluir a(s) seguinte(s) regra(s) de alerta do Syslog."
 
 #: syslog_alerts.php:175
-#, fuzzy
 msgid "Delete Syslog Alert Rule(s)"
 msgstr "Excluir Regra(s) de Alerta do Syslog"
 
 #: syslog_alerts.php:179
-#, fuzzy
 msgid "Click 'Continue' to Disable the following Syslog Alert Rule(s)."
 msgstr "Clique em 'Continuar' para desativar a(s) seguinte(s) regra(s) de alerta do Syslog."
 
 #: syslog_alerts.php:185
-#, fuzzy
 msgid "Disable Syslog Alert Rule(s)"
 msgstr "Desativar Regra(s) de Alerta do Syslog"
 
 #: syslog_alerts.php:189
-#, fuzzy
 msgid "Click 'Continue' to Enable the following Syslog Alert Rule(s)."
 msgstr "Clique em 'Continuar' para ativar a(s) seguinte(s) regra(s) de alerta do Syslog."
 
 #: syslog_alerts.php:195
-#, fuzzy
 msgid "Enable Syslog Alert Rule(s)"
 msgstr "Ativar Regra(s) de Alerta do Syslog"
 
 #: syslog_alerts.php:199
-#, fuzzy
 msgid "Click 'Continue' to Export the following Syslog Alert Rule(s)."
 msgstr "Clique em 'Continuar' para Exportar a(s) seguinte(s) regra(s) de alerta do Syslog."
 
 #: syslog_alerts.php:205
-#, fuzzy
 msgid "Export Syslog Alert Rule(s)"
 msgstr "Exportar Regra(s) de Alerta do Syslog"
 
@@ -1210,17 +1040,14 @@ msgid "1 Month"
 msgstr "1 mês"
 
 #: syslog_alerts.php:449
-#, fuzzy, php-format
 msgid "Alert Edit [edit: %s]"
 msgstr "Editar Alerta [editar: %s]"
 
 #: syslog_alerts.php:451 syslog_alerts.php:458 syslog_alerts.php:465
-#, fuzzy
 msgid "Alert Edit [new]"
 msgstr "Editar alerta Editar [novo]"
 
 #: syslog_alerts.php:463 syslog_alerts.php:467
-#, fuzzy
 msgid "New Alert Rule"
 msgstr "Nova regra de alerta"
 
@@ -1237,22 +1064,18 @@ msgid "Name"
 msgstr "Nome"
 
 #: syslog_alerts.php:491
-#, fuzzy
 msgid "Please describe this Alert."
 msgstr "Por favor, descreva este Alerta."
 
 #: syslog_alerts.php:499
-#, fuzzy
 msgid "What is the Severity Level of this Alert?"
 msgstr "Qual é o nível de severidade deste alerta?"
 
 #: syslog_alerts.php:506
-#, fuzzy
 msgid "Reporting Level"
 msgstr "Método de relatório"
 
 #: syslog_alerts.php:507
-#, fuzzy
 msgid "For recording Re-Alert Cycles, should the Alert be tracked at the System or Device level."
 msgstr "Para registrar Ciclos de Re-alerta, o Alerta deve ser rastreado no nível do Sistema ou Dispositivo."
 
@@ -1261,12 +1084,10 @@ msgid "System"
 msgstr "Sistema"
 
 #: syslog_alerts.php:514
-#, fuzzy
 msgid "Reporting Method"
 msgstr "Método de relatório"
 
 #: syslog_alerts.php:515
-#, fuzzy
 msgid "Define how to Alert on the syslog messages."
 msgstr "Defina como Alertar sobre as mensagens do syslog."
 
@@ -1275,28 +1096,23 @@ msgid "Individual"
 msgstr "Individual"
 
 #: syslog_alerts.php:523
-#, fuzzy
 msgid "For the 'Threshold' method, If the number seen is above this value an Alert will be triggered."
 msgstr "Para o método 'Threshold', se o número visto estiver acima desse valor, um alerta será acionado."
 
 #: syslog_alerts.php:531 syslog_alerts.php:879 syslog_removal.php:703
 #: syslog_reports.php:741
-#, fuzzy
 msgid "Match Type"
 msgstr "Tipo de Jogo"
 
 #: syslog_alerts.php:532 syslog_removal.php:442
-#, fuzzy
 msgid "Define how you would like this string matched.  If using the SQL Expression type you may use any valid SQL expression to generate the alarm.  Available fields include 'message', 'facility', 'priority', and 'host'."
 msgstr "Defina como você gostaria que esta corda correspondesse.  Se utilizar o tipo de expressão SQL Expression, pode utilizar qualquer expressão SQL válida para gerar o alarme.  Os campos disponíveis incluem \"message\", \"facility\", \"priority\" e \"host\"."
 
 #: syslog_alerts.php:539 syslog_reports.php:444 syslog_reports.php:471
-#, fuzzy
 msgid "Message Match String"
 msgstr "Mensagem Syslog Match String"
 
 #: syslog_alerts.php:540 syslog_removal.php:450
-#, fuzzy
 msgid "Enter the matching component of the syslog message, the facility or host name, or the SQL where clause if using the SQL Expression Match Type."
 msgstr "Insira o componente correspondente da mensagem do syslog, o nome da instalação ou do host ou a cláusula SQL where se estiver usando o SQL Expression Match Type."
 
@@ -1308,7 +1124,6 @@ msgid "Enabled"
 msgstr "Activado"
 
 #: syslog_alerts.php:551
-#, fuzzy
 msgid "Is this Alert Enabled?"
 msgstr "Este Alerta está activado?"
 
@@ -1317,12 +1132,10 @@ msgid "Disabled"
 msgstr "Desativado"
 
 #: syslog_alerts.php:557
-#, fuzzy
 msgid "Re-Alert Cycle"
 msgstr "Re-Alerta Ciclo"
 
 #: syslog_alerts.php:561
-#, fuzzy
 msgid "Do not resend this alert again for the same host, until this amount of time has elapsed. For threshold based alarms, this applies to all hosts."
 msgstr "Não reenvie este alerta novamente para o mesmo host, até que este período de tempo tenha decorrido. Para alarmes baseados em limiares, isso se aplica a todos os hosts."
 
@@ -1331,7 +1144,6 @@ msgid "Notes"
 msgstr "Notas"
 
 #: syslog_alerts.php:568
-#, fuzzy
 msgid "Space for Notes on the Alert"
 msgstr "Espaço para Notas sobre o Alerta"
 
@@ -1344,27 +1156,22 @@ msgid "Notification List"
 msgstr "Lista de Notificações"
 
 #: syslog_alerts.php:581 syslog_reports.php:491
-#, fuzzy
 msgid "Use the contents of this Notification List to dictate who should be notified and how."
 msgstr "Use o conteúdo desta Lista de Notificações para ditar quem deve ser notificado e como."
 
 #: syslog_alerts.php:589
-#, fuzzy
 msgid "Emails to Notify"
 msgstr "Emails para Notificar"
 
 #: syslog_alerts.php:592
-#, fuzzy
 msgid "Please enter a comma delimited list of Email addresses to inform.  If you wish to send out Email to a recipient in SMS format, please prefix that recipient's Email address with <b>'sms@'</b>.  For example, if the recipients SMS address is <b>'2485551212@mycarrier.net'</b>, you would enter it as <b>'sms@2485551212@mycarrier.net'</b> and it will be formatted as an SMS message."
 msgstr "Digite uma lista delimitada por vírgula de endereços de e-mail para informar.  Se desejar enviar um e-mail para um destinatário em formato SMS, por favor prefira o endereço de e-mail desse destinatário com <b>'sms@'</b>.  Por exemplo, se o endereço SMS do destinatário for <b>'2485551212@mycarrier.net'</b>, introduza-o como <b>'sms@2485551212@mycarrier.net'</b> e será formatado como uma mensagem SMS."
 
 #: syslog_alerts.php:598 syslog_reports.php:479
-#, fuzzy
 msgid "Email Body Text"
 msgstr "Corpo de Texto"
 
 #: syslog_alerts.php:601
-#, fuzzy
 msgid "This information will appear in the body of the Alert just before the Alert details."
 msgstr "A informação que será contida no corpo do relatório."
 
@@ -1373,7 +1180,6 @@ msgid "Open Ticket"
 msgstr "Bilhete livre"
 
 #: syslog_alerts.php:614
-#, fuzzy
 msgid "Should a Help Desk Ticket be opened for this Alert.  NOTE: The Ticket command script will be populated with several 'ALERT_' environment variables for convenience."
 msgstr "Caso seja aberto um Ticket de Help Desk para este Alerta. NOTA: O script de comando Ticket será preenchido com várias variáveis de ambiente 'ALERT_' por conveniência."
 
@@ -1394,7 +1200,6 @@ msgid "Command"
 msgstr "Comando"
 
 #: syslog_alerts.php:623
-#, fuzzy
 msgid "When an Alert is triggered, run the following command.  The following replacement variables are available <b>'&lt;HOSTNAME&gt;'</b>, <b>'&lt;ALERTID&gt;'</b>, <b>'&lt;MESSAGE&gt;'</b>, <b>'&lt;FACILITY&gt;'</b>, <b>'&lt;PRIORITY&gt;'</b>, <b>'&lt;SEVERITY&gt;'</b>.  Please note that <b>'&lt;HOSTNAME&gt;'</b> is only available on individual thresholds.  These replacement values can appear on the command line, or be gathered from the environment of the script.  When used from the environment, those variables will be prefixed with 'ALERT_'."
 msgstr "Quando um alerta é disparado, execute o seguinte comando.  As seguintes variáveis de substituição estão disponíveis <b>'&lt;HOSTNAME&gt;'</b>, <b>'&lt;ALERTID&gt;'</b>, <b>'&lt;MESSAGE&gt;'</b>, <b>'&lt;FACILITY&gt;'</b>, <b>'&lt;PRIORITY&gt;'</b>, <b>'&lt;SEVERITY&gt;'</b>.  Note que <b>'&lt;HOSTNAME&gt;'</b> só está disponível em limiares individuais."
 
@@ -1408,7 +1213,6 @@ msgid "Import"
 msgstr "Importar"
 
 #: syslog_alerts.php:849
-#, fuzzy
 msgid "Syslog Alert Filters"
 msgstr "Filtros de Alerta Syslog"
 
@@ -1417,12 +1221,10 @@ msgid "Method"
 msgstr "Método"
 
 #: syslog_alerts.php:877
-#, fuzzy
 msgid "Threshold Count"
 msgstr "Contagem Limiar"
 
 #: syslog_alerts.php:880 syslog_removal.php:704 syslog_reports.php:742
-#, fuzzy
 msgid "Search String"
 msgstr "Procurar cadeia de caracteres"
 
@@ -1435,7 +1237,6 @@ msgid "Last Modified"
 msgstr "A data da última modificação do objecto, no fuso horário do site."
 
 #: syslog_alerts.php:883 syslog_removal.php:707 syslog_reports.php:747
-#, fuzzy
 msgid "By User"
 msgstr "Utilizador:"
 
@@ -1444,32 +1245,26 @@ msgid "Multiple"
 msgstr "Multiplo"
 
 #: syslog_alerts.php:913
-#, fuzzy
 msgid "No Syslog Alerts Defined"
 msgstr "Nenhum Alerta Syslog Definido"
 
 #: syslog_alerts.php:944
-#, fuzzy
 msgid "Import Alert Rule from Local File"
 msgstr "Importar regra de alerta do file local"
 
 #: syslog_alerts.php:945
-#, fuzzy
 msgid "If the XML file containing the Alert Rule definition data is located on your local machine, select it here."
 msgstr "Se o arquivo XML contendo os dados de definição da Regra de alerta estiver localizado em sua máquina local, selecione-o aqui."
 
 #: syslog_alerts.php:950
-#, fuzzy
 msgid "Import Alert Rule from Text"
 msgstr "Importar regra de alerta do texto"
 
 #: syslog_alerts.php:951
-#, fuzzy
 msgid "If you have the XML file containing the Alert Ruledefinition data as text, you can paste it into this box to import it."
 msgstr "Se tiver o ficheiro XML contendo os dados da Definição de Regra de Alerta como texto, pode colá-lo nesta caixa para o importar."
 
 #: syslog_alerts.php:962
-#, fuzzy
 msgid "Import Alert Rule"
 msgstr "Importar regra de alerta"
 
@@ -1478,7 +1273,6 @@ msgid "Imported"
 msgstr "Importado"
 
 #: syslog_alerts.php:1039
-#, fuzzy, php-format
 msgid "NOTE: Alert '%s' %s!"
 msgstr "NOTA: Alerta '%s' %s!"
 
@@ -1487,7 +1281,6 @@ msgid "Updated"
 msgstr "Actualizado"
 
 #: syslog_alerts.php:1041
-#, fuzzy, php-format
 msgid "ERROR: Alert '%s' %s Failed!"
 msgstr "ERRO: Alerta '%s' %s Fracassou!"
 
@@ -1496,97 +1289,78 @@ msgid "Update"
 msgstr "Atualizar"
 
 #: syslog_removal.php:40
-#, fuzzy
 msgid "Reprocess"
 msgstr "Reprocessar"
 
 #: syslog_removal.php:181
-#, fuzzy
 msgid "Click 'Continue' to Delete the following Syslog Removal Rule(s)."
 msgstr "Clique em 'Continuar' para excluir a(s) seguinte(s) regra(s) de remoção do syslog."
 
 #: syslog_removal.php:187
-#, fuzzy
 msgid "Delete Syslog Removal Rule(s)"
 msgstr "Excluir Regra(s) de Remoção do Syslog"
 
 #: syslog_removal.php:191
-#, fuzzy
 msgid "Click 'Continue' to Disable the following Syslog Removal Rule(s)."
 msgstr "Clique em 'Continuar' para desativar a(s) seguinte(s) regra(s) de remoção de syslogs."
 
 #: syslog_removal.php:197
-#, fuzzy
 msgid "Disable Syslog Removal Rule(s)"
 msgstr "Desativar Regra(s) de Remoção do Syslog"
 
 #: syslog_removal.php:201
-#, fuzzy
 msgid "Click 'Continue' to Enable the following Syslog Removal Rule(s)."
 msgstr "Clique em 'Continuar' para ativar a(s) seguinte(s) regra(s) de remoção de syslogs."
 
 #: syslog_removal.php:207
-#, fuzzy
 msgid "Enable Syslog Removal Rule(s)"
 msgstr "Ativar Regra(s) de Remoção do Syslog"
 
 #: syslog_removal.php:211
-#, fuzzy
 msgid "Click 'Continue' to Re-process the following Syslog Removal Rule(s)."
 msgstr "Clique em 'Continuar' para reprocessar a(s) seguinte(s) regra(s) de remoção de syslogs."
 
 #: syslog_removal.php:217
-#, fuzzy
 msgid "Retroactively Process Syslog Removal Rule(s)"
 msgstr "Processar retroativamente a(s) regra(s) de remoção de syslogs"
 
 #: syslog_removal.php:221
-#, fuzzy
 msgid "Click 'Continue' to Export the following Syslog Removal Rule(s)."
 msgstr "Clique em 'Continuar' para Exportar a(s) seguinte(s) regra(s) de remoção de syslogs."
 
 #: syslog_removal.php:227
-#, fuzzy
 msgid "Export Syslog Removal Rule(s)"
 msgstr "Exportar Regra(s) de Remoção do Syslog"
 
 #: syslog_removal.php:342
-#, fuzzy, php-format
 msgid "Rule '%s' resulted in %s/%s messages removed/transferred"
 msgstr "Houve %s de mensagens removidas e %s de mensagens transferidas"
 
 #: syslog_removal.php:398
-#, fuzzy, php-format
 msgid "Removal Rule Edit [edit: %s]"
 msgstr "Edição de regras de remoção [editar: %s]"
 
 #: syslog_removal.php:400 syslog_removal.php:407
-#, fuzzy
 msgid "Removal Rule Edit [new]"
 msgstr "Editar regra de remoção Editar [novo]"
 
 #: syslog_removal.php:402 syslog_removal.php:415
-#, fuzzy
 msgid "New Removal Record"
 msgstr "Novo registro de remoção"
 
 #: syslog_removal.php:411
-#, fuzzy
 msgid "New Removal Rule"
 msgstr "Nova regra de remoção"
 
 #: syslog_removal.php:421
-#, fuzzy
 msgid "Removal Rule Details"
 msgstr "Detalhes da regra de remoção"
 
 #: syslog_removal.php:425
-#, fuzzy
 msgid "Removal Rule Name"
 msgstr "Nome da regra de remoção"
 
 #: syslog_removal.php:426
-#, fuzzy
 msgid "Please describe this Removal Rule."
 msgstr "Por favor, descreva esta Regra de Remoção."
 
@@ -1595,22 +1369,18 @@ msgid "Enabled?"
 msgstr "Ativado?"
 
 #: syslog_removal.php:434
-#, fuzzy
 msgid "Is this Removal Rule Enabled?"
 msgstr "Esta regra de remoção está habilitada?"
 
 #: syslog_removal.php:441 syslog_reports.php:436
-#, fuzzy
 msgid "String Match Type"
 msgstr "Tipo de Correspondência de Cordas"
 
 #: syslog_removal.php:449
-#, fuzzy
 msgid "Syslog Message Match String"
 msgstr "Mensagem Syslog Match String"
 
 #: syslog_removal.php:460
-#, fuzzy
 msgid "Method of Removal"
 msgstr "Método de Remoção"
 
@@ -1619,17 +1389,14 @@ msgid "Deletion"
 msgstr "Apagamento"
 
 #: syslog_removal.php:462
-#, fuzzy
 msgid "Transferal"
 msgstr "Transferência"
 
 #: syslog_removal.php:466
-#, fuzzy
 msgid "Removal Rule Notes"
 msgstr "Notas de regra de remoção"
 
 #: syslog_removal.php:469
-#, fuzzy
 msgid "Space for Notes on the Removal rule"
 msgstr "Espaço para Notas sobre a regra de Remoção"
 
@@ -1638,12 +1405,10 @@ msgid "Rules"
 msgstr "Regras"
 
 #: syslog_removal.php:676
-#, fuzzy
 msgid "Syslog Removal Rule Filters"
 msgstr "Filtros de regra de remoção de syslog"
 
 #: syslog_removal.php:701
-#, fuzzy
 msgid "Removal Name"
 msgstr "Nome da Remoção"
 
@@ -1652,87 +1417,70 @@ msgid "Transfer"
 msgstr "Transferir"
 
 #: syslog_removal.php:734
-#, fuzzy
 msgid "No Syslog Removal Rules Defined"
 msgstr "Sem regras de remoção de syslogs definidas"
 
 #: syslog_removal.php:765
-#, fuzzy
 msgid "Import Removal Rule from Local File"
 msgstr "Importar regra de remoção do file local"
 
 #: syslog_removal.php:766
-#, fuzzy
 msgid "If the XML file containing the Removal Rule definition data is located on your local machine, select it here."
 msgstr "Se o arquivo XML contendo os dados de definição da Regra de Remoção estiver localizado em sua máquina local, selecione-o aqui."
 
 #: syslog_removal.php:771
-#, fuzzy
 msgid "Import Removal Rule from Text"
 msgstr "Importar regra de remoção do texto"
 
 #: syslog_removal.php:772
-#, fuzzy
 msgid "If you have the XML file containing the Removal Rule definition data as text, you can paste it into this box to import it."
 msgstr "Se tiver o ficheiro XML contendo os dados de definição da Regra de Remoção como texto, pode colá-lo nesta caixa para o importar."
 
 #: syslog_removal.php:783
-#, fuzzy
 msgid "Import Removal Rule"
 msgstr "Importar regra de remoção"
 
 #: syslog_removal.php:861
-#, fuzzy, php-format
 msgid "NOTE: Removal Rule '%s' %s!"
 msgstr "NOTA: Regra de Remoção '%s' %s!"
 
 #: syslog_removal.php:863
-#, fuzzy, php-format
 msgid "ERROR: Removal Rule '%s' %s Failed!"
 msgstr "ERRO: Regra de Remoção '%s' %s Falha!"
 
 #: syslog_reports.php:169
-#, fuzzy
 msgid "Click 'Continue' to Delete the following Syslog Report(s)."
 msgstr "Clique em 'Continuar' para excluir o(s) seguinte(s) relatório(s) do Syslog."
 
 #: syslog_reports.php:175
-#, fuzzy
 msgid "Delete Syslog Report(s)"
 msgstr "Excluir relatório(s) Syslog"
 
 #: syslog_reports.php:179
-#, fuzzy
 msgid "Click 'Continue' to Disable the following Syslog Report(s)."
 msgstr "Clique em 'Continuar' para desativar o(s) seguinte(s) relatório(s) Syslog."
 
 #: syslog_reports.php:185
-#, fuzzy
 msgid "Disable Syslog Report(s)"
 msgstr "Desativar relatório(s) Syslog"
 
 #: syslog_reports.php:189
-#, fuzzy
 msgid "Click 'Continue' to Enable the following Syslog Report(s)."
 msgstr "Clique em 'Continuar' para ativar o(s) seguinte(s) Relatório(s) Syslog."
 
 #: syslog_reports.php:195
-#, fuzzy
 msgid "Enable Syslog Report(s)"
 msgstr "Ativar relatório(s) Syslog"
 
 #: syslog_reports.php:199
-#, fuzzy
 msgid "Click 'Continue' to Export the following Syslog Report Rule(s)."
 msgstr "Clique em 'Continuar' para Exportar a(s) seguinte(s) regra(s) de relatório do Syslog."
 
 #: syslog_reports.php:205
-#, fuzzy
 msgid "Export Syslog Report Rule(s)"
 msgstr "Exportar Regra(s) do Relatório Syslog"
 
 #: syslog_reports.php:210
-#, fuzzy
 msgid "You must select at least one Syslog Report."
 msgstr "Você deve selecionar pelo menos um Relatório do Syslog."
 
@@ -1741,37 +1489,30 @@ msgid "Return"
 msgstr "Devolução"
 
 #: syslog_reports.php:391
-#, fuzzy, php-format
 msgid "Report Edit [edit: %s]"
 msgstr "Report Edit [editar: %s] (editar: %s)"
 
 #: syslog_reports.php:393 syslog_reports.php:398
-#, fuzzy
 msgid "Report Edit [new]"
 msgstr "Relatório Editar [novo]"
 
 #: syslog_reports.php:395 syslog_reports.php:400
-#, fuzzy
 msgid "New Report Record"
 msgstr "Novo registro de relatório"
 
 #: syslog_reports.php:422
-#, fuzzy
 msgid "Please describe this Report."
 msgstr "Descreva este Relatório."
 
 #: syslog_reports.php:429
-#, fuzzy
 msgid "Is this Report Enabled?"
 msgstr "Este relatório está habilitado?"
 
 #: syslog_reports.php:437
-#, fuzzy
 msgid "Define how you would like this string matched."
 msgstr "Defina como você gostaria que esta corda correspondesse."
 
 #: syslog_reports.php:445 syslog_reports.php:472
-#, fuzzy
 msgid "The matching component of the syslog message."
 msgstr "O componente correspondente da mensagem do syslog."
 
@@ -1780,42 +1521,34 @@ msgid "Frequency"
 msgstr "Frequência"
 
 #: syslog_reports.php:453
-#, fuzzy
 msgid "How often should this Report be sent to the distribution list?"
 msgstr "Com que frequência este Relatório deve ser enviado para a lista de distribuição?"
 
 #: syslog_reports.php:460 syslog_reports.php:744
-#, fuzzy
 msgid "Send Time"
 msgstr "Hora de envio"
 
 #: syslog_reports.php:461
-#, fuzzy
 msgid "What time of day should this report be sent?"
 msgstr "A que hora do dia este relatório deve ser enviado?"
 
 #: syslog_reports.php:468
-#, fuzzy
 msgid "Report Format"
 msgstr "Notas do relatório"
 
 #: syslog_reports.php:482
-#, fuzzy
 msgid "The information that will be contained in the body of the Report."
 msgstr "A informação que será contida no corpo do relatório."
 
 #: syslog_reports.php:501
-#, fuzzy
 msgid "Comma delimited list of Email addresses to send the report to."
 msgstr "Lista delimitada por vírgulas de endereços de e-mail para onde enviar o relatório."
 
 #: syslog_reports.php:511
-#, fuzzy
 msgid "Space for Notes on the Report"
 msgstr "Espaço para Notas sobre o Relatório"
 
 #: syslog_reports.php:714
-#, fuzzy
 msgid "Syslog Report Filters"
 msgstr "Filtros de Relatórios Syslog"
 
@@ -1828,41 +1561,33 @@ msgid "Last Sent"
 msgstr "Enviado pela última vez"
 
 #: syslog_reports.php:776
-#, fuzzy
 msgid "No Syslog Reports Defined"
 msgstr "Nenhum relatório Syslog definido"
 
 #: syslog_reports.php:807
-#, fuzzy
 msgid "Import Report Rule from Local File"
 msgstr "Importar regra de relatório do file local"
 
 #: syslog_reports.php:808
-#, fuzzy
 msgid "If the XML file containing the Report Rule definition data is located on your local machine, select it here."
 msgstr "Se o arquivo XML contendo os dados de definição da Regra de Relatório estiver localizado em sua máquina local, selecione-o aqui."
 
 #: syslog_reports.php:813
-#, fuzzy
 msgid "Import Report Rule from Text"
 msgstr "Importar regra de relatório do texto"
 
 #: syslog_reports.php:814
-#, fuzzy
 msgid "If you have the XML file containing the Report Rule definition data as text, you can paste it into this box to import it."
 msgstr "Se tiver o ficheiro XML contendo os dados de definição da Regra de Relatório como texto, pode colá-lo nesta caixa para o importar."
 
 #: syslog_reports.php:825
-#, fuzzy
 msgid "Import Report Data"
 msgstr "Importar dados do relatório"
 
 #: syslog_reports.php:903
-#, fuzzy, php-format
 msgid "NOTE: Report Rule '%s' %s!"
 msgstr "NOTA: Relatório Regra '%s' %s!"
 
 #: syslog_reports.php:905
-#, fuzzy, php-format
 msgid "ERROR: Report Rule '%s' %s Failed!"
 msgstr "ERRO: Relatório Regra '%s' %s Falhou!"


### PR DESCRIPTION
This PR cleans up the Portuguese localizations. 
- Resolved 270+ fuzzy strings in pt-PT.
- Fixed potential full-width placeholder issues in both PT and BR.
- Standardized technical terms for the Syslog interface.