### PR TITLE
Locales: Global syntax fix for variable placeholders

### DIFF
--- a/locales/po/el-GR.po
+++ b/locales/po/el-GR.po
@@ -483,18 +483,18 @@ msgstr "%d Εβδομάδες"
 #: setup.php:1304 setup.php:1323
 #, php-format
 msgid "%d Month"
-msgstr "% d Μήνα"
+msgstr "%d Month"
 
 #: setup.php:1305 setup.php:1306 setup.php:1307 setup.php:1308 setup.php:1309
 #: setup.php:1324 setup.php:1325 setup.php:1326 setup.php:1327 setup.php:1328
 #, php-format
 msgid "%d Months"
-msgstr "% d Μήνας"
+msgstr "%d Months"
 
 #: setup.php:1310 setup.php:1329
 #, php-format
 msgid "%d Year"
-msgstr "% d Έτος"
+msgstr "%d Year"
 
 #: setup.php:1333 syslog_reports.php:769
 msgid "Never"

--- a/locales/po/ka-GE.po
+++ b/locales/po/ka-GE.po
@@ -4,25 +4,37 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
-msgstr "Project-Id-Version: Cacti\nReport-Msgid-Bugs-To: developers@cacti.net\nPOT-Creation-Date: 2025-03-07 14:31-0500\nPO-Revision-Date: 2025-10-15 06:26+0000\nLast-Translator: Ekaterine papava <papava.e@gtu.ge>\nLanguage-Team: Georgian <https://translate.cacti.net/projects/cacti/syslog/ka/>\nLanguage: ka-GE\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 5.11.4\n"
+msgstr ""
+"Project-Id-Version: Cacti\n"
+"Report-Msgid-Bugs-To: developers@cacti.net\n"
+"POT-Creation-Date: 2025-03-07 14:31-0500\n"
+"PO-Revision-Date: 2025-10-15 06:26+0000\n"
+"Last-Translator: Ekaterine papava <papava.e@gtu.ge>\n"
+"Language-Team: Georgian <https://translate.cacti.net/projects/cacti/syslog/ka/>\n"
+"Language: ka-GE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.11.4\n"
 
 #: functions.php:72
 msgid "Save Failed.  Remote Data Collectors in Sync Mode are not allowed to Save Rules.  Save from the Main Cacti Server instead."
-msgstr ""
+msgstr "შენახვა ვერ მოხერხდა.  სინქრონიზაციის რეჟიმში დისტანციურ მონაცემთა შემგროვებლებს არ აქვთ წესების შენახვის უფლება.  ამის ნაცვლად, შეინახეთ მთავარი Cacti სერვერიდან."
 
 #: functions.php:116
 msgid "Please use an HTML Email Client"
-msgstr ""
+msgstr "გთხოვთ, გამოიყენოთ HTML ელფოსტის კლიენტი"
 
 #: functions.php:1304
 #, php-format
 msgid "Cacti Syslog Threshold Alert '%s' for Host '%s'"
-msgstr ""
+msgstr "Cacti Syslog ზღურბლის გაფრთხილება '%s ' ჰოსტისთვის '%s '"
 
 #: functions.php:1306
 #, php-format
 msgid "Cacti Syslog Threshold Alert '%s'"
-msgstr ""
+msgstr "Cacti Syslog ბარიერის გაფრთხილება '%s'"
 
 #: functions.php:1314 syslog.php:1896 syslog_alerts.php:874
 msgid "Alert Name"
@@ -49,12 +61,12 @@ msgstr "ემთხვევა სტრიქონს"
 #: functions.php:1329 functions.php:1368
 #, php-format
 msgid "Cacti Syslog Alert '%s' for Host '%s'"
-msgstr ""
+msgstr "Cacti Syslog Alert '%s' ჰოსტისთვის '%s'"
 
 #: functions.php:1331 functions.php:1370
 #, php-format
 msgid "Cacti Syslog Alert '%s'"
-msgstr ""
+msgstr "Cacti Syslog Alert '%s'"
 
 #: functions.php:1340
 msgid "Hostname"
@@ -77,11 +89,11 @@ msgstr "შეტყობინება"
 #: functions.php:1351
 #, php-format
 msgid "WARNING: A Syslog Threshold Alert has Been Triggered for Host '%s'"
-msgstr ""
+msgstr "გაფრთხილება: ამოქმედდა Syslog ბარიერის გაფრთხილება ჰოსტისთვის '%s'"
 
 #: functions.php:1353
 msgid "WARNING: A Syslog Threshold Alert has Been Triggered"
-msgstr ""
+msgstr "გაფრთხილება: გააქტიურებულია Syslog ბარიერის გაფრთხილება"
 
 #: functions.php:1360
 msgid "Name:"
@@ -134,7 +146,7 @@ msgstr "სიმძ:"
 #: functions.php:1490 functions.php:1544
 #, php-format
 msgid "Event Alert - %s"
-msgstr ""
+msgstr "მოვლენის გაფრთხილება -%s"
 
 #: functions.php:1548
 msgid ", Count:"
@@ -147,23 +159,23 @@ msgstr "ჰოსტი"
 #: functions.php:2116
 #, php-format
 msgid "Event Report - %s"
-msgstr ""
+msgstr "მოვლენის ანგარიში -%s"
 
 #: setup.php:34
 msgid "Please rename either your config.php.dist or config_local.php.dist files in the syslog directory, and change setup your database before installing."
-msgstr ""
+msgstr "გთხოვთ, გადაარქვათ სახელი თქვენი config.php.dist ან config_local.php.dist ფაილებს syslog დირექტორიაში და შეცვალეთ თქვენი მონაცემთა ბაზის დაყენება ინსტალაციამდე."
 
 #: setup.php:274
 msgid "Syslog 2.0 Requires an Entire Reinstall.  Please uninstall Syslog and Remove all Data before Installing.  Migration is possible, but you must plan this in advance.  No automatic migration is supported."
-msgstr ""
+msgstr "Syslog 2.0 მოითხოვს სრულ ხელახლა ინსტალაციას.  გთხოვთ, წაშალოთ Syslog და წაშალოთ ყველა მონაცემი ინსტალაციამდე.  მიგრაცია შესაძლებელია, მაგრამ ეს წინასწარ უნდა დაგეგმოთ.  ავტომატური მიგრაცია არ არის მხარდაჭერილი."
 
 #: setup.php:862
 msgid "What upgrade/install type do you wish to use"
-msgstr ""
+msgstr "რა სახის განახლება/ინსტალაცია გსურთ გამოიყენოთ"
 
 #: setup.php:863
 msgid "When you have very large tables, performing a Truncate will be much quicker.  If you are concerned about archive data, you can choose either Inline, which will freeze your browser for the period of this upgrade, or background, which will create a background process to bring your old syslog data from a backup table to the new syslog format.  Again this process can take several hours."
-msgstr ""
+msgstr "როდესაც თქვენ გაქვთ ძალიან დიდი მაგიდები, Truncate-ის შესრულება ბევრად უფრო სწრაფი იქნება.  თუ თქვენ გაწუხებთ არქივის მონაცემები, შეგიძლიათ აირჩიოთ Inline, რომელიც გაყინავს თქვენს ბრაუზერს ამ განახლების პერიოდისთვის, ან ფონი, რომელიც შექმნის ფონურ პროცესს თქვენი ძველი syslog მონაცემების სარეზერვო ცხრილიდან ახალ syslog ფორმატში გადასატანად.  ისევ ამ პროცესს შეიძლება რამდენიმე საათი დასჭირდეს."
 
 #: setup.php:866
 msgid "Truncate Syslog Table"
@@ -183,7 +195,7 @@ msgstr "მონაცემთა ბაზის საცავის ძრ
 
 #: setup.php:874
 msgid "You have the option to make this a partitioned table by days."
-msgstr ""
+msgstr "თქვენ გაქვთ შესაძლებლობა გახადოთ ეს დაყოფილი ცხრილი დღეების მიხედვით."
 
 #: setup.php:877
 msgid "MyISAM Storage"
@@ -199,7 +211,7 @@ msgstr "მონაცემთა ბაზის არქიტექტუ�
 
 #: setup.php:884
 msgid "You have the option to make this a partitioned table by days.  You can create multiple partitions per day."
-msgstr ""
+msgstr "თქვენ გაქვთ შესაძლებლობა გახადოთ ეს დაყოფილი ცხრილი დღეების მიხედვით.  თქვენ შეგიძლიათ შექმნათ რამდენიმე დანაყოფი დღეში."
 
 #: setup.php:887
 msgid "Traditional Table"
@@ -215,7 +227,7 @@ msgstr "შენარჩუნების პოლიტიკა"
 
 #: setup.php:894
 msgid "Choose how many days of Syslog values you wish to maintain in the database."
-msgstr ""
+msgstr "აირჩიეთ რამდენი დღის Syslog მნიშვნელობების შენარჩუნება გსურთ მონაცემთა ბაზაში."
 
 #: setup.php:914
 msgid "Partitions per Day"
@@ -223,7 +235,7 @@ msgstr "დანაყოფი დღეში"
 
 #: setup.php:915
 msgid "Select the number of partitions per day that you wish to create."
-msgstr ""
+msgstr "შეარჩიეთ ტიხრების რაოდენობა დღეში, რომლის შექმნაც გსურთ."
 
 #: setup.php:918 setup.php:919 setup.php:920 setup.php:921 setup.php:922
 #, php-format
@@ -245,40 +257,40 @@ msgstr "Syslog %s მრჩეველი"
 
 #: setup.php:937
 msgid "WARNING: Syslog Upgrade is Time Consuming!!!"
-msgstr ""
+msgstr "გაფრთხილება: Syslog-ის განახლება შრომატევადია!!!"
 
 #: setup.php:938
 msgid "The upgrade of the 'main' syslog table can be a very time consuming process.  As such, it is recommended that you either reduce the size of your syslog table prior to upgrading, or choose the background option</p> <p>If you choose the background option, your legacy syslog table will be renamed, and a new syslog table will be created.  Then, an upgrade process will be launched in the background.  Again, this background process can quite a bit of time to complete.  However, your data will be preserved</p> <p>Regardless of your choice, all existing removal and alert rules will be maintained during the upgrade process.</p> <p>Press <b>'Upgrade'</b> to proceed with the upgrade, or <b>'Cancel'</b> to return to the Plugins menu."
-msgstr ""
+msgstr "\"მთავარი\" syslog ცხრილის განახლება შეიძლება იყოს ძალიან შრომატევადი პროცესი.  როგორც ასეთი, რეკომენდირებულია ან შეამციროთ თქვენი syslog ცხრილის ზომა განახლებამდე, ან აირჩიოთ ფონის ვარიანტი</p> <p>თუ აირჩევთ ფონურ ვარიანტს, თქვენს მოძველებულ syslog ცხრილს სახელი გადაერქვა და შეიქმნება ახალი syslog ცხრილი.  ამის შემდეგ, განახლების პროცესი ფონზე დაიწყება.  ისევ და ისევ, ამ ფონური პროცესის დასრულებას საკმაოდ ცოტა დრო შეუძლია.  თუმცა, თქვენი მონაცემები შენარჩუნდება</p> <p>თქვენი არჩევანის მიუხედავად, ყველა არსებული წაშლისა და გაფრთხილების წესი შენარჩუნდება განახლების პროცესში.</p> <p>დააჭირეთ <b>'განახლება'</b> განახლების გასაგრძელებლად ან <b>'გაუქმება'</b> დანამატების მენიუში დასაბრუნებლად."
 
 #: setup.php:941
 msgid "You can also select the retention duration.  Please keep in mind that if you have several hosts logging to syslog, this table can become quite large.  So, if not using partitioning, you might want to keep the size smaller."
-msgstr ""
+msgstr "თქვენ ასევე შეგიძლიათ აირჩიოთ შენახვის ხანგრძლივობა.  გთხოვთ გაითვალისწინოთ, რომ თუ თქვენ გაქვთ syslog-ში შესული რამდენიმე ჰოსტი, ეს ცხრილი შეიძლება საკმაოდ დიდი გახდეს.  ასე რომ, თუ არ იყენებთ დაყოფას, შეიძლება გინდოდეთ შეინარჩუნოთ ზომა უფრო მცირე."
 
 #: setup.php:941
 msgid "You can also set the MySQL storage engine.  If you have not tuned you system for InnoDB storage properties, it is strongly recommended that you utilize the MyISAM storage engine."
-msgstr ""
+msgstr "თქვენ ასევე შეგიძლიათ დააყენოთ MySQL შენახვის ძრავა.  თუ თქვენ არ დაარეგულირეთ სისტემა InnoDB შენახვის თვისებებისთვის, რეკომენდებულია MyISAM შენახვის ძრავის გამოყენება."
 
 #: setup.php:941
 msgid "You have several options to choose from when installing Syslog.  The first is the Database Architecture.  You should elect to utilize Table Partitioning to prevent the size of the tables from becoming excessive thus slowing queries."
-msgstr ""
+msgstr "Syslog-ის ინსტალაციისას რამდენიმე ვარიანტი გაქვთ ასარჩევად.  პირველი არის მონაცემთა ბაზის არქიტექტურა.  თქვენ უნდა აირჩიოთ Table Partitioning-ის გამოყენება, რათა თავიდან აიცილოთ ცხრილების ზომა გადაჭარბებული და ამით შეანელოთ მოთხოვნები."
 
 #: setup.php:945
 #, php-format
 msgid "Syslog %s Settings"
-msgstr ""
+msgstr "Syslog%s პარამეტრები"
 
 #: setup.php:972
 msgid "What uninstall method do you want to use?"
-msgstr ""
+msgstr "დეინსტალაციის რომელი მეთოდის გამოყენება გსურთ?"
 
 #: setup.php:973
 msgid "When uninstalling syslog, you can remove everything, or only components, just in case you plan on re-installing in the future."
-msgstr ""
+msgstr "syslog-ის დეინსტალაციისას შეგიძლიათ წაშალოთ ყველაფერი, ან მხოლოდ კომპონენტები, მხოლოდ იმ შემთხვევაში, თუ მომავალში აპირებთ ხელახლა ინსტალაციას."
 
 #: setup.php:975
 msgid "Remove Everything (Logs, Tables, Settings)"
-msgstr ""
+msgstr "ყველაფრის წაშლა ( ჟურნალები, ცხრილები, პარამეტრები)"
 
 #: setup.php:975
 msgid "Syslog Data Only"
@@ -286,7 +298,7 @@ msgstr "მხოლოდ syslog-ის მონაცემები"
 
 #: setup.php:995
 msgid "Syslog Uninstall Preferences"
-msgstr ""
+msgstr "Syslog დეინსტალაციის პარამეტრები"
 
 #: setup.php:1020
 msgid "Uninstall"
@@ -311,15 +323,15 @@ msgstr "Syslog ჩართულია"
 
 #: setup.php:1075
 msgid "If this checkbox is set, records will be transferred from the Syslog Incoming table to the main syslog table and Alerts and Reports will be enabled.  Please keep in mind that if the system is disabled log entries will still accumulate into the Syslog Incoming table as this is defined by the rsyslog or syslog-ng process."
-msgstr ""
+msgstr "თუ ეს ჩამრთველი დაყენებულია, ჩანაწერები გადაიცემა Syslog Incoming ცხრილიდან მთავარ syslog ცხრილში და ჩართული იქნება Alerts and Reports.  გთხოვთ, გაითვალისწინოთ, რომ თუ სისტემა გამორთულია, ჟურნალის ჩანაწერები კვლავ დაგროვდება Syslog Incoming ცხრილში, რადგან ეს განისაზღვრება rsyslog ან syslog-ng პროცესით."
 
 #: setup.php:1080
 msgid "Enable Statistics Gathering"
-msgstr ""
+msgstr "სტატისტიკის შეგროვების ჩართვა"
 
 #: setup.php:1081
 msgid "If this checkbox is set, statistics on where syslog messages are arriving from will be maintained.  This statistical information can be used to render things such as heat maps."
-msgstr ""
+msgstr "თუ ეს მოსანიშნი ველი დაყენებულია, შენარჩუნდება სტატისტიკა იმის შესახებ, თუ საიდან მოდის syslog შეტყობინებები.  ეს სტატისტიკური ინფორმაცია შეიძლება გამოყენებულ იქნას ისეთი საგნების გამოსატანად, როგორიცაა სითბოს რუქები."
 
 #: setup.php:1086
 msgid "Strip Domains"
@@ -327,7 +339,7 @@ msgstr "დომენების წაჭრა"
 
 #: setup.php:1087
 msgid "A comma delimited list of domains that you wish to remove from the syslog hostname, Examples would be 'mydomain.com, otherdomain.com'"
-msgstr ""
+msgstr "მძიმით გამოყოფილი დომენების სია, რომელთა ამოღება გსურთ syslog ჰოსტის სახელიდან, მაგალითები იქნება 'mydomain.com, otherdomain.com'"
 
 #: setup.php:1094
 msgid "Validate Hostnames"
@@ -335,7 +347,7 @@ msgstr "ჰოსტის სახელების გადამოწმ�
 
 #: setup.php:1095
 msgid "If this checkbox is set, all hostnames are validated.  If the hostname is not valid. All records are assigned to a special host called 'invalidhost'.  This setting can impact syslog processing time on large systems.  Therefore, use of this setting should only be used when other means are not in place to prevent this from happening."
-msgstr ""
+msgstr "თუ ეს ჩამრთველი დაყენებულია, ყველა ჰოსტის სახელი დამოწმებულია.  თუ ჰოსტის სახელი არასწორია. ყველა ჩანაწერი მინიჭებულია სპეციალურ ჰოსტზე სახელწოდებით 'invalidhost'.  ამ პარამეტრს შეუძლია გავლენა მოახდინოს სისტემების დამუშავების დროზე დიდ სისტემებზე.  ამიტომ, ამ პარამეტრის გამოყენება უნდა მოხდეს მხოლოდ მაშინ, როდესაც სხვა საშუალებები არ არსებობს ამის თავიდან ასაცილებლად."
 
 #: setup.php:1100
 msgid "Refresh Interval"
@@ -343,7 +355,7 @@ msgstr "განახლების შუალედი"
 
 #: setup.php:1101
 msgid "This is the time in seconds before the page refreshes."
-msgstr ""
+msgstr "ეს არის წამებში გვერდის განახლებამდე."
 
 #: setup.php:1107
 msgid "Max Report Records"
@@ -351,7 +363,7 @@ msgstr "მაქს. ანგარიშის ჩანაწერები
 
 #: setup.php:1108
 msgid "For Threshold based Alerts, what is the maximum number that you wish to show in the report.  This is used to limit the size of the html log and Email."
-msgstr ""
+msgstr "ზღურბლზე დაფუძნებული გაფრთხილებისთვის, რა არის მაქსიმალური რაოდენობა, რომლის ჩვენებაც გსურთ ანგარიშში.  ეს გამოიყენება html ჟურნალის და ელფოსტის ზომის შეზღუდვისთვის."
 
 #: setup.php:1112 setup.php:1113 setup.php:1114 setup.php:1115 setup.php:1116
 #: setup.php:1117
@@ -361,11 +373,11 @@ msgstr "%d ჩანაწერი"
 
 #: setup.php:1121
 msgid "Command for Opening Tickets"
-msgstr ""
+msgstr "ბილეთების გახსნის ბრძანება"
 
 #: setup.php:1122
 msgid "This command will be executed for opening Help Desk Tickets.  The command will be required to parse multiple input parameters as follows: <b>--alert-name</b>, <b>--severity</b>, <b>--hostlist</b>, <b>--message</b>.  The hostlist will be a comma delimited list of hosts impacted by the alert."
-msgstr ""
+msgstr "ეს ბრძანება შესრულდება Help Desk Tickets-ის გასახსნელად.  ბრძანება საჭირო იქნება მრავალი შეყვანის პარამეტრის გასაანალიზებლად შემდეგნაირად: <b>--alert-name</b>, <b>--severity</b>, <b>--hostlist</b>, <b>--message</b>.  ჰოსტინგის სია იქნება მძიმით გამოყოფილი ჰოსტების სია, რომლებიც გავლენას ახდენს გაფრთხილებაზე."
 
 #: setup.php:1128
 msgid "HTML Notification Settings"
@@ -373,19 +385,19 @@ msgstr "HTML გაფრთხილების მორგება"
 
 #: setup.php:1133
 msgid "Enable HTML Based Email"
-msgstr ""
+msgstr "ჩართეთ HTML დაფუძნებული ელფოსტა"
 
 #: setup.php:1134
 msgid "If this checkbox is set, all Emails will be sent in HTML format.  Otherwise, Emails will be sent in plain text."
-msgstr ""
+msgstr "თუ ეს მოსანიშნი ველი დაყენებულია, ყველა ელფოსტა გაიგზავნება HTML ფორმატში.  წინააღმდეგ შემთხვევაში, ელ.წერილი გაიგზავნება მარტივი ტექსტით."
 
 #: setup.php:1139
 msgid "Format File to Use"
-msgstr ""
+msgstr "გამოსაყენებლად ფაილის ფორმატირება"
 
 #: setup.php:1142
 msgid "Choose the custom html wrapper and CSS file to use.  This file contains both html and CSS to wrap around your report.  If it contains more than simply CSS, you need to place a special <REPORT> tag inside of the file.  This format tag will be replaced by the report content.  These files are located in the 'formats' directory."
-msgstr ""
+msgstr "აირჩიეთ მორგებული html შეფუთვა და CSS ფაილი გამოსაყენებლად.  ეს ფაილი შეიცავს როგორც html-ს, ასევე CSS-ს თქვენი ანგარიშის შესაფუთად.  თუ ის შეიცავს უფრო მეტს, ვიდრე უბრალოდ CSS, თქვენ უნდა მოათავსოთ სპეციალური <REPORT> ტეგი ფაილის შიგნით.  ეს ფორმატის თეგი შეიცვლება მოხსენების შინაარსით.  ეს ფაილები განთავსებულია \"ფორმატების\" დირექტორიაში."
 
 #: setup.php:1146
 msgid "Data Retention Settings"
@@ -397,7 +409,7 @@ msgstr "Syslog-ის შენარჩუნება"
 
 #: setup.php:1152
 msgid "This is the number of days to keep events."
-msgstr ""
+msgstr "ეს არის მოვლენების შესანარჩუნებლად დღეების რაოდენობა."
 
 #: setup.php:1158
 msgid "Syslog Alert Retention"
@@ -405,27 +417,27 @@ msgstr "Syslog-ის განგაშების შენარჩუნე
 
 #: setup.php:1159
 msgid "This is the number of days to keep alert logs."
-msgstr ""
+msgstr "ეს არის დღეების რაოდენობა გაფრთხილების ჟურნალის შესანახად."
 
 #: setup.php:1165
 msgid "Remote Message Processing"
-msgstr ""
+msgstr "დისტანციური შეტყობინებების დამუშავება"
 
 #: setup.php:1169
 msgid "Enable Remote Data Collector Message Processing"
-msgstr ""
+msgstr "ჩართეთ დისტანციური მონაცემთა შემგროვებლის შეტყობინებების დამუშავება"
 
 #: setup.php:1170
 msgid "If your Remote Data Collectors have their own Syslog databases and process their messages independently, check this checkbox.  By checking this Checkbox, your Remote Data Collectors will need to maintain their own 'config_local.php' file in order to inform Syslog to use an independent database for message display and processing.  Please use the template file 'config_local.php.dist' for this purpose.  WARNING: Syslog tables will be automatically created as soon as this option is enabled."
-msgstr ""
+msgstr "თუ თქვენს დისტანციურ მონაცემთა შემგროვებლებს აქვთ საკუთარი Syslog მონაცემთა ბაზა და დამოუკიდებლად ამუშავებენ მათ შეტყობინებებს, მონიშნეთ ეს ველი.  ამ მონიშვნის ველის მონიშვნით, თქვენს დისტანციურ მონაცემთა შემგროვებლებს დასჭირდებათ შეინარჩუნონ საკუთარი 'config_local.php' ფაილი, რათა აცნობონ Syslog-ს, გამოიყენოს დამოუკიდებელი მონაცემთა ბაზა შეტყობინებების ჩვენებისა და დამუშავებისთვის.  გთხოვთ გამოიყენოთ შაბლონის ფაილი 'config_local.php.dist' ამ მიზნით.  გაფრთხილება: Syslog ცხრილები ავტომატურად შეიქმნება ამ პარამეტრის ჩართვისთანავე."
 
 #: setup.php:1175
 msgid "Remote Data Collector Rules Sync"
-msgstr ""
+msgstr "დისტანციური მონაცემთა შემგროვებლის წესების სინქრონიზაცია"
 
 #: setup.php:1176
 msgid "If your Remote Data Collectors have their own Syslog databases and process thrie messages independently, check this checkbox if you wish the Main Cacti databases Alerts, Removal and Report rules to be sent to the Remote Cacti System."
-msgstr ""
+msgstr "თუ თქვენს დისტანციურ მონაცემთა შემგროვებლებს აქვთ საკუთარი Syslog მონაცემთა ბაზა და დამოუკიდებლად ამუშავებენ სამ შეტყობინებას, მონიშნეთ ეს ველი, თუ გსურთ, რომ ძირითადი Cacti მონაცემთა ბაზების გაფრთხილებები, ამოღება და მოხსენების წესები გაიგზავნოს Remote Cacti სისტემაში."
 
 #: setup.php:1249 syslog_removal.php:37
 msgid "Delete"
@@ -600,12 +612,12 @@ msgstr "Syslog-ის ანგარიშები"
 
 #: setup.php:1500
 msgid "Display Syslog in Range"
-msgstr ""
+msgstr "აჩვენეთ Syslog დიაპაზონში"
 
 #: setup.php:1548
 #, php-format
 msgid "There were %s Device records removed from the Syslog database"
-msgstr ""
+msgstr "იყო%s მოწყობილობის ჩანაწერები ამოღებული Syslog მონაცემთა ბაზიდან"
 
 #: setup.php:1564
 msgid "Syslog Utilities"
@@ -617,7 +629,7 @@ msgstr "სისტემური ჟურნალის მოწყობ�
 
 #: setup.php:1571
 msgid "This menu pick provides a means to remove Devices that are no longer reporting into Cacti's syslog server."
-msgstr ""
+msgstr "მენიუს ეს არჩევანი საშუალებას გაძლევთ წაშალოთ მოწყობილობები, რომლებიც აღარ იწერენ Cacti-ს სისტემის ანგარიშების სერვერზე."
 
 #: syslog.php:58
 msgid "Syslog Viewer"
@@ -685,7 +697,7 @@ msgstr "ჩანაწერები"
 
 #: syslog.php:384
 msgid "No Syslog Statistics Found"
-msgstr ""
+msgstr "Syslog სტატისტიკა ვერ მოიძებნა"
 
 #: syslog.php:492 syslog.php:1793 syslog.php:1801 syslog.php:1901
 #: syslog_alerts.php:509
@@ -745,16 +757,16 @@ msgstr "ნაგულისხმევი"
 #: syslog.php:1066
 #, php-format
 msgid " [ Start: '%s' to End: '%s', Unprocessed Messages: %s ]"
-msgstr ""
+msgstr "[დაწყება: '%s' დასრულებამდე: '%s', დაუმუშავებელი შეტყობინებები:%s ]"
 
 #: syslog.php:1068
 #, php-format
 msgid "[ Unprocessed Messages: %s ]"
-msgstr ""
+msgstr "[ დაუმუშავებელი შეტყობინებები:%s ]"
 
 #: syslog.php:1078
 msgid "Enter a search term"
-msgstr ""
+msgstr "შეიყვანეთ საძიებო ტერმინი"
 
 #: syslog.php:1090
 msgid "Select Device(s)"
@@ -771,7 +783,7 @@ msgstr "ყველა მონიშნული მოწყობილო�
 #: syslog.php:1329
 #, php-format
 msgid "Syslog Message Filter %s"
-msgstr ""
+msgstr "Syslog შეტყობინების ფილტრი%s"
 
 #: syslog.php:1336
 msgid "Timespan"
@@ -811,11 +823,11 @@ msgstr "დროის წანაცვლება წინ"
 
 #: syslog.php:1403
 msgid "Return filter values to their user defined defaults"
-msgstr ""
+msgstr "დააბრუნეთ ფილტრის მნიშვნელობები მომხმარებლის მიერ განსაზღვრულ ნაგულისხმევად"
 
 #: syslog.php:1404
 msgid "Export Records to CSV"
-msgstr ""
+msgstr "ჩანაწერების ექსპორტი CSV-ში"
 
 #: syslog.php:1405
 msgid "Save"
@@ -823,7 +835,7 @@ msgstr "შენახვა"
 
 #: syslog.php:1405
 msgid "Save Default Settings"
-msgstr ""
+msgstr "ნაგულისხმევი პარამეტრების შენახვა"
 
 #: syslog.php:1411 syslog_alerts.php:886
 msgid "Alerts"
@@ -831,7 +843,7 @@ msgstr "განგაშები"
 
 #: syslog.php:1411
 msgid "View Syslog Alert Rules"
-msgstr ""
+msgstr "იხილეთ Syslog Alert წესები"
 
 #: syslog.php:1412
 msgid "Removals"
@@ -839,7 +851,7 @@ msgstr "წაშლები"
 
 #: syslog.php:1412
 msgid "View Syslog Removal Rules"
-msgstr ""
+msgstr "იხილეთ Syslog-ის წაშლის წესები"
 
 #: syslog.php:1413 syslog_reports.php:750
 msgid "Reports"
@@ -847,7 +859,7 @@ msgstr "ანგარიშები"
 
 #: syslog.php:1413
 msgid "View Syslog Reports"
-msgstr ""
+msgstr "იხილეთ Syslog ანგარიშები"
 
 #: syslog.php:1433
 msgid "Devices"
@@ -883,7 +895,7 @@ msgstr "განახლება"
 
 #: syslog.php:1596
 msgid "Facilities to filter on"
-msgstr ""
+msgstr "ფილტრაციის საშუალებები"
 
 #: syslog.php:1597
 msgid "All Facilities"
@@ -987,7 +999,7 @@ msgstr "განგაში წაიშალა"
 
 #: syslog.php:1934
 msgid "No Alert Log Messages"
-msgstr ""
+msgstr "გაფრთხილების ჟურნალის შეტყობინებები არ არის"
 
 #: syslog.php:1991 syslog.php:2014 syslog.php:2033 syslog.php:2034
 msgid "All Programs"
@@ -995,35 +1007,35 @@ msgstr "ყველა პროგრამა"
 
 #: syslog_alerts.php:169
 msgid "Click 'Continue' to Delete the following Syslog Alert Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ 'გაგრძელებაზე' შემდეგი Syslog გაფრთხილების წესების წასაშლელად."
 
 #: syslog_alerts.php:175
 msgid "Delete Syslog Alert Rule(s)"
-msgstr ""
+msgstr "Syslog გაფრთხილების წესი(ებ)ის წაშლა"
 
 #: syslog_alerts.php:179
 msgid "Click 'Continue' to Disable the following Syslog Alert Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“, რათა გამორთოთ შემდეგი Syslog გაფრთხილების წესი(ები)."
 
 #: syslog_alerts.php:185
 msgid "Disable Syslog Alert Rule(s)"
-msgstr ""
+msgstr "გამორთეთ Syslog Alert წესები(ები)"
 
 #: syslog_alerts.php:189
 msgid "Click 'Continue' to Enable the following Syslog Alert Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ 'გაგრძელებაზე', რათა ჩართოთ შემდეგი Syslog გაფრთხილების წესები."
 
 #: syslog_alerts.php:195
 msgid "Enable Syslog Alert Rule(s)"
-msgstr ""
+msgstr "Syslog Alert წესები(ებ)ის ჩართვა"
 
 #: syslog_alerts.php:199
 msgid "Click 'Continue' to Export the following Syslog Alert Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ 'გაგრძელებაზე' შემდეგი Syslog გაფრთხილების წესი(ებ)ის ექსპორტისთვის."
 
 #: syslog_alerts.php:205
 msgid "Export Syslog Alert Rule(s)"
-msgstr ""
+msgstr "Syslog გაფრთხილების წესი(ებ)ის ექსპორტი"
 
 #: syslog_alerts.php:208 syslog_removal.php:230 syslog_reports.php:208
 msgid "Continue"
@@ -1031,16 +1043,16 @@ msgstr "გაგრძელება"
 
 #: syslog_alerts.php:309 syslog_reports.php:304
 msgid "The SQL Syntax Entered is invalid.  Please correct your SQL.<br>"
-msgstr ""
+msgstr "შეყვანილი SQL სინტაქსი არასწორია.  გთხოვთ, შეასწოროთ თქვენი SQL.<br>"
 
 #: syslog_alerts.php:310 syslog_reports.php:305
 #, php-format
 msgid "The Pre-processed SQL is:<br><br> %s"
-msgstr ""
+msgstr "წინასწარ დამუშავებული SQL არის:<br><br>%s"
 
 #: syslog_alerts.php:319 syslog_reports.php:314
 msgid "The processed SQL was invalid.  Please correct your SQL"
-msgstr ""
+msgstr "დამუშავებული SQL არასწორი იყო.  გთხოვთ შეასწოროთ თქვენი SQL"
 
 #: syslog_alerts.php:386
 msgid "Not Set"
@@ -1057,7 +1069,7 @@ msgstr "1 თვე"
 #: syslog_alerts.php:449
 #, php-format
 msgid "Alert Edit [edit: %s]"
-msgstr ""
+msgstr "გაფრთხილების რედაქტირება [რედაქტირება:%s ]"
 
 #: syslog_alerts.php:451 syslog_alerts.php:458 syslog_alerts.php:465
 msgid "Alert Edit [new]"
@@ -1081,11 +1093,11 @@ msgstr "სახელი"
 
 #: syslog_alerts.php:491
 msgid "Please describe this Alert."
-msgstr ""
+msgstr "გთხოვთ აღწეროთ ეს გაფრთხილება."
 
 #: syslog_alerts.php:499
 msgid "What is the Severity Level of this Alert?"
-msgstr ""
+msgstr "რა არის ამ გაფრთხილების სიმძიმის დონე?"
 
 #: syslog_alerts.php:506
 msgid "Reporting Level"
@@ -1093,7 +1105,7 @@ msgstr "ანგარიშის დონე"
 
 #: syslog_alerts.php:507
 msgid "For recording Re-Alert Cycles, should the Alert be tracked at the System or Device level."
-msgstr ""
+msgstr "ხელახალი გაფრთხილების ციკლების ჩასაწერად, გაფრთხილების თვალყურის დევნება უნდა მოხდეს სისტემის ან მოწყობილობის დონეზე."
 
 #: syslog_alerts.php:509
 msgid "System"
@@ -1105,7 +1117,7 @@ msgstr "ანგარიშების გზავნის მეთოდ�
 
 #: syslog_alerts.php:515
 msgid "Define how to Alert on the syslog messages."
-msgstr ""
+msgstr "განსაზღვრეთ როგორ გავაფრთხილოთ სისტემური შეტყობინებები."
 
 #: syslog_alerts.php:517 syslog_alerts.php:901
 msgid "Individual"
@@ -1113,7 +1125,7 @@ msgstr "ინდივიდუალური"
 
 #: syslog_alerts.php:523
 msgid "For the 'Threshold' method, If the number seen is above this value an Alert will be triggered."
-msgstr ""
+msgstr "„Threshold“ მეთოდისთვის, თუ ნანახი რიცხვი აღემატება ამ მნიშვნელობას, გაფრთხილება ამოქმედდება."
 
 #: syslog_alerts.php:531 syslog_alerts.php:879 syslog_removal.php:703
 #: syslog_reports.php:741
@@ -1122,7 +1134,7 @@ msgstr "დამთხვევის ტიპი"
 
 #: syslog_alerts.php:532 syslog_removal.php:442
 msgid "Define how you would like this string matched.  If using the SQL Expression type you may use any valid SQL expression to generate the alarm.  Available fields include 'message', 'facility', 'priority', and 'host'."
-msgstr ""
+msgstr "განსაზღვრეთ, თუ როგორ გსურთ ეს სტრიქონი შეესაბამებოდეს.  თუ იყენებთ SQL Expression ტიპის, შეგიძლიათ გამოიყენოთ ნებისმიერი მოქმედი SQL გამოხატულება განგაშის შესაქმნელად.  ხელმისაწვდომი ველები მოიცავს „შეტყობინებას“, „მოწყობილობას“, „პრიორიტეტს“ და „მასპინძელს“."
 
 #: syslog_alerts.php:539 syslog_reports.php:444 syslog_reports.php:471
 msgid "Message Match String"
@@ -1130,7 +1142,7 @@ msgstr "შეტყობინება ემთხვევა სტრი�
 
 #: syslog_alerts.php:540 syslog_removal.php:450
 msgid "Enter the matching component of the syslog message, the facility or host name, or the SQL where clause if using the SQL Expression Match Type."
-msgstr ""
+msgstr "შეიყვანეთ syslog შეტყობინების შესატყვისი კომპონენტი, ობიექტის ან ჰოსტის სახელი, ან SQL where პუნქტი, თუ იყენებთ SQL Expression Match Type."
 
 #: syslog_alerts.php:550 syslog_alerts.php:553 syslog_alerts.php:721
 #: syslog_alerts.php:878 syslog_removal.php:436 syslog_removal.php:548
@@ -1141,7 +1153,7 @@ msgstr "ჩართულია"
 
 #: syslog_alerts.php:551
 msgid "Is this Alert Enabled?"
-msgstr ""
+msgstr "ეს გაფრთხილება ჩართულია?"
 
 #: syslog_alerts.php:553 syslog_removal.php:436 syslog_reports.php:431
 msgid "Disabled"
@@ -1153,7 +1165,7 @@ msgstr "თავიდან განგაშის ციკლი"
 
 #: syslog_alerts.php:561
 msgid "Do not resend this alert again for the same host, until this amount of time has elapsed. For threshold based alarms, this applies to all hosts."
-msgstr ""
+msgstr "არ გაუგზავნოთ ეს გაფრთხილება ხელახლა იმავე მასპინძლისთვის, სანამ ეს დრო არ გავიდა. ზღურბლზე დაფუძნებული სიგნალიზაციისთვის, ეს ეხება ყველა ჰოსტს."
 
 #: syslog_alerts.php:565 syslog_reports.php:508
 msgid "Notes"
@@ -1161,7 +1173,7 @@ msgstr "შენიშვნები"
 
 #: syslog_alerts.php:568
 msgid "Space for Notes on the Alert"
-msgstr ""
+msgstr "გაფრთხილების შესახებ შენიშვნების ადგილი"
 
 #: syslog_alerts.php:576
 msgid "Email Options"
@@ -1173,7 +1185,7 @@ msgstr "გაფრთხილებების სია"
 
 #: syslog_alerts.php:581 syslog_reports.php:491
 msgid "Use the contents of this Notification List to dictate who should be notified and how."
-msgstr ""
+msgstr "გამოიყენეთ ამ შეტყობინებების სიის შიგთავსი, რათა უკარნახოთ ვის და როგორ უნდა ეცნობოს."
 
 #: syslog_alerts.php:589
 msgid "Emails to Notify"
@@ -1181,7 +1193,7 @@ msgstr "ელფოსტები გაფრთხილებისთვ�
 
 #: syslog_alerts.php:592
 msgid "Please enter a comma delimited list of Email addresses to inform.  If you wish to send out Email to a recipient in SMS format, please prefix that recipient's Email address with <b>'sms@'</b>.  For example, if the recipients SMS address is <b>'2485551212@mycarrier.net'</b>, you would enter it as <b>'sms@2485551212@mycarrier.net'</b> and it will be formatted as an SMS message."
-msgstr ""
+msgstr "გთხოვთ, შეიყვანოთ მძიმით გამოყოფილი ელფოსტის მისამართების სია ინფორმირებისთვის.  თუ გსურთ, გაუგზავნოთ ელფოსტა მიმღებს SMS ფორმატში, გთხოვთ, მიამაგროთ ამ მიმღების ელფოსტის მისამართი <b>'sms@'</b>.  მაგალითად, თუ მიმღების SMS მისამართია <b>'2485551212@mycarrier.net'</b>, თქვენ შეიყვანთ მას როგორც <b>'sms@2485551212@mycarrier.net'</b> და ის დაფორმატდება როგორც SMS შეტყობინება."
 
 #: syslog_alerts.php:598 syslog_reports.php:479
 msgid "Email Body Text"
@@ -1189,7 +1201,7 @@ msgstr "ელფოსტის სხეულის ტექსტი"
 
 #: syslog_alerts.php:601
 msgid "This information will appear in the body of the Alert just before the Alert details."
-msgstr ""
+msgstr "ეს ინფორმაცია გამოჩნდება Alert-ის სხეულში გაფრთხილების დეტალების წინ."
 
 #: syslog_alerts.php:613
 msgid "Open Ticket"
@@ -1197,7 +1209,7 @@ msgstr "ბილეთის გახსნა"
 
 #: syslog_alerts.php:614
 msgid "Should a Help Desk Ticket be opened for this Alert.  NOTE: The Ticket command script will be populated with several 'ALERT_' environment variables for convenience."
-msgstr ""
+msgstr "უნდა გაიხსნას Help Desk ბილეთი ამ გაფრთხილებისთვის.  შენიშვნა: მოხერხებულობისთვის Ticket ბრძანების სკრიპტი შევსებული იქნება რამდენიმე 'ALERT_' გარემოს ცვლადით."
 
 #: syslog_alerts.php:616 syslog_alerts.php:727 syslog_alerts.php:903
 #: syslog_removal.php:554 syslog_removal.php:724 syslog_reports.php:592
@@ -1217,7 +1229,7 @@ msgstr "ბრძანება"
 
 #: syslog_alerts.php:623
 msgid "When an Alert is triggered, run the following command.  The following replacement variables are available <b>'&lt;HOSTNAME&gt;'</b>, <b>'&lt;ALERTID&gt;'</b>, <b>'&lt;MESSAGE&gt;'</b>, <b>'&lt;FACILITY&gt;'</b>, <b>'&lt;PRIORITY&gt;'</b>, <b>'&lt;SEVERITY&gt;'</b>.  Please note that <b>'&lt;HOSTNAME&gt;'</b> is only available on individual thresholds.  These replacement values can appear on the command line, or be gathered from the environment of the script.  When used from the environment, those variables will be prefixed with 'ALERT_'."
-msgstr ""
+msgstr "როდესაც გაფრთხილება ამოქმედდება, გაუშვით შემდეგი ბრძანება.  შემდეგი შემცვლელი ცვლადები ხელმისაწვდომია <b>'&lt;HOSTNAME&gt;'</b>, <b>'&lt;ALERTID&gt;'</b>, <b>'&lt;MESSAGE&gt;'</b>, <b>'&lt;FACILITY&gt;'</b>, <b>'&lt;PRIORI' <b>'&lt;SEVERITY&gt;'</b>.  გთხოვთ, გაითვალისწინოთ, რომ <b>'&lt;HOSTNAME&gt;'</b> ხელმისაწვდომია მხოლოდ ცალკეულ ზღვრებზე.  ეს შემცვლელი მნიშვნელობები შეიძლება გამოჩნდეს ბრძანების სტრიქონზე, ან შეგროვდეს სკრიპტის გარემოდან.  როდესაც გამოიყენება გარემოდან, ამ ცვლადების პრეფიქსი იქნება 'ALERT_'."
 
 #: syslog_alerts.php:731 syslog_reports.php:596
 msgid "Rows"
@@ -1230,7 +1242,7 @@ msgstr "შემოტანა"
 
 #: syslog_alerts.php:849
 msgid "Syslog Alert Filters"
-msgstr ""
+msgstr "Syslog Alert ფილტრები"
 
 #: syslog_alerts.php:876 syslog_removal.php:705
 msgid "Method"
@@ -1262,23 +1274,23 @@ msgstr "მრავალი"
 
 #: syslog_alerts.php:913
 msgid "No Syslog Alerts Defined"
-msgstr ""
+msgstr "არ არის განსაზღვრული Syslog Alerts"
 
 #: syslog_alerts.php:944
 msgid "Import Alert Rule from Local File"
-msgstr ""
+msgstr "გაფრთხილების წესის იმპორტი ლოკალური ფაილიდან"
 
 #: syslog_alerts.php:945
 msgid "If the XML file containing the Alert Rule definition data is located on your local machine, select it here."
-msgstr ""
+msgstr "თუ XML ფაილი, რომელიც შეიცავს Alert Rule-ის განმარტების მონაცემებს, მდებარეობს თქვენს ადგილობრივ აპარატზე, აირჩიეთ აქ."
 
 #: syslog_alerts.php:950
 msgid "Import Alert Rule from Text"
-msgstr ""
+msgstr "გაფრთხილების წესის იმპორტი ტექსტიდან"
 
 #: syslog_alerts.php:951
 msgid "If you have the XML file containing the Alert Ruledefinition data as text, you can paste it into this box to import it."
-msgstr ""
+msgstr "თუ თქვენ გაქვთ XML ფაილი, რომელიც შეიცავს Alert Ruledefinition მონაცემებს ტექსტად, შეგიძლიათ ჩასვათ იგი ამ ველში მის იმპორტირებისთვის."
 
 #: syslog_alerts.php:962
 msgid "Import Alert Rule"
@@ -1291,7 +1303,7 @@ msgstr "შემოტანილია"
 #: syslog_alerts.php:1039
 #, php-format
 msgid "NOTE: Alert '%s' %s!"
-msgstr ""
+msgstr "შენიშვნა: გაფრთხილება '%s'%s !"
 
 #: syslog_alerts.php:1039 syslog_removal.php:861 syslog_reports.php:903
 msgid "Updated"
@@ -1300,7 +1312,7 @@ msgstr "განახლებულია"
 #: syslog_alerts.php:1041
 #, php-format
 msgid "ERROR: Alert '%s' %s Failed!"
-msgstr ""
+msgstr "შეცდომა: გაფრთხილება '%s'%s ვერ მოხერხდა!"
 
 #: syslog_alerts.php:1041 syslog_removal.php:863 syslog_reports.php:905
 msgid "Update"
@@ -1312,57 +1324,57 @@ msgstr "თავიდან დამუშავება"
 
 #: syslog_removal.php:181
 msgid "Click 'Continue' to Delete the following Syslog Removal Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ 'გაგრძელებაზე' შემდეგი Syslog-ის წაშლის წესი(ებ)ის წასაშლელად."
 
 #: syslog_removal.php:187
 msgid "Delete Syslog Removal Rule(s)"
-msgstr ""
+msgstr "Syslog-ის წაშლის წესი(ებ)ის წაშლა"
 
 #: syslog_removal.php:191
 msgid "Click 'Continue' to Disable the following Syslog Removal Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“, რათა გამორთოთ შემდეგი Syslog-ის წაშლის წესი(ები)."
 
 #: syslog_removal.php:197
 msgid "Disable Syslog Removal Rule(s)"
-msgstr ""
+msgstr "Syslog-ის წაშლის წესი(ებ)ის გამორთვა"
 
 #: syslog_removal.php:201
 msgid "Click 'Continue' to Enable the following Syslog Removal Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ 'გაგრძელებაზე', რათა ჩართოთ შემდეგი Syslog ამოღების წესი(ები)."
 
 #: syslog_removal.php:207
 msgid "Enable Syslog Removal Rule(s)"
-msgstr ""
+msgstr "Syslog-ის წაშლის წესი(ებ)ის ჩართვა"
 
 #: syslog_removal.php:211
 msgid "Click 'Continue' to Re-process the following Syslog Removal Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“ შემდეგი Syslog-ის წაშლის წესი(ებ)ის ხელახლა დასამუშავებლად."
 
 #: syslog_removal.php:217
 msgid "Retroactively Process Syslog Removal Rule(s)"
-msgstr ""
+msgstr "რეტროაქტიულად დამუშავება Syslog ამოღების წეს(ებ)ი"
 
 #: syslog_removal.php:221
 msgid "Click 'Continue' to Export the following Syslog Removal Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ 'გაგრძელებაზე' შემდეგი Syslog-ის წაშლის წესი(ებ)ის ექსპორტისთვის."
 
 #: syslog_removal.php:227
 msgid "Export Syslog Removal Rule(s)"
-msgstr ""
+msgstr "Syslog ამოღების წესი(ებ)ის ექსპორტი"
 
 #: syslog_removal.php:342
 #, php-format
 msgid "Rule '%s' resulted in %s/%s messages removed/transferred"
-msgstr ""
+msgstr "წესმა „%s“ გამოიწვია%s /%s შეტყობინება წაშლილი/გადატანილი"
 
 #: syslog_removal.php:398
 #, php-format
 msgid "Removal Rule Edit [edit: %s]"
-msgstr ""
+msgstr "მოხსნის წესის რედაქტირება [რედაქტირება:%s ]"
 
 #: syslog_removal.php:400 syslog_removal.php:407
 msgid "Removal Rule Edit [new]"
-msgstr ""
+msgstr "მოხსნის წესის რედაქტირება [ახალი]"
 
 #: syslog_removal.php:402 syslog_removal.php:415
 msgid "New Removal Record"
@@ -1382,7 +1394,7 @@ msgstr "წაშლის წესის სახელი"
 
 #: syslog_removal.php:426
 msgid "Please describe this Removal Rule."
-msgstr ""
+msgstr "გთხოვთ, აღწეროთ მოხსნის ეს წესი."
 
 #: syslog_removal.php:433 syslog_reports.php:428
 msgid "Enabled?"
@@ -1390,7 +1402,7 @@ msgstr "ჩართულია?"
 
 #: syslog_removal.php:434
 msgid "Is this Removal Rule Enabled?"
-msgstr ""
+msgstr "ჩართულია ეს წაშლის წესი?"
 
 #: syslog_removal.php:441 syslog_reports.php:436
 msgid "String Match Type"
@@ -1398,7 +1410,7 @@ msgstr "სტრიქონის დამთხვევის ტიპი"
 
 #: syslog_removal.php:449
 msgid "Syslog Message Match String"
-msgstr ""
+msgstr "Syslog შეტყობინების შესატყვისი სტრიქონი"
 
 #: syslog_removal.php:460
 msgid "Method of Removal"
@@ -1418,7 +1430,7 @@ msgstr "წაშლის წესის შენიშვნები"
 
 #: syslog_removal.php:469
 msgid "Space for Notes on the Removal rule"
-msgstr ""
+msgstr "ადგილი ამოღების წესის შესახებ შენიშვნებისთვის"
 
 #: syslog_removal.php:558 syslog_removal.php:712
 msgid "Rules"
@@ -1426,7 +1438,7 @@ msgstr "წესები"
 
 #: syslog_removal.php:676
 msgid "Syslog Removal Rule Filters"
-msgstr ""
+msgstr "Syslog ამოღების წესის ფილტრები"
 
 #: syslog_removal.php:701
 msgid "Removal Name"
@@ -1438,23 +1450,23 @@ msgstr "გადაყვანა"
 
 #: syslog_removal.php:734
 msgid "No Syslog Removal Rules Defined"
-msgstr ""
+msgstr "არ არის განსაზღვრული Syslog-ის წაშლის წესები"
 
 #: syslog_removal.php:765
 msgid "Import Removal Rule from Local File"
-msgstr ""
+msgstr "იმპორტის ამოღების წესი ლოკალური ფაილიდან"
 
 #: syslog_removal.php:766
 msgid "If the XML file containing the Removal Rule definition data is located on your local machine, select it here."
-msgstr ""
+msgstr "თუ XML ფაილი, რომელიც შეიცავს ამოღების წესის განსაზღვრის მონაცემებს, მდებარეობს თქვენს ადგილობრივ აპარატზე, აირჩიეთ აქ."
 
 #: syslog_removal.php:771
 msgid "Import Removal Rule from Text"
-msgstr ""
+msgstr "ტექსტიდან ამოღების წესის იმპორტი"
 
 #: syslog_removal.php:772
 msgid "If you have the XML file containing the Removal Rule definition data as text, you can paste it into this box to import it."
-msgstr ""
+msgstr "თუ თქვენ გაქვთ XML ფაილი, რომელიც შეიცავს Removal Rule-ის განმარტების მონაცემებს ტექსტად, შეგიძლიათ ჩასვათ იგი ამ ველში მის იმპორტირებისთვის."
 
 #: syslog_removal.php:783
 msgid "Import Removal Rule"
@@ -1463,16 +1475,16 @@ msgstr "წაშლის წესის შემოტანა"
 #: syslog_removal.php:861
 #, php-format
 msgid "NOTE: Removal Rule '%s' %s!"
-msgstr ""
+msgstr "შენიშვნა: წაშლის წესი '%s'%s !"
 
 #: syslog_removal.php:863
 #, php-format
 msgid "ERROR: Removal Rule '%s' %s Failed!"
-msgstr ""
+msgstr "შეცდომა: წაშლის წესი '%s'%s ვერ მოხერხდა!"
 
 #: syslog_reports.php:169
 msgid "Click 'Continue' to Delete the following Syslog Report(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“ შემდეგი Syslog ანგარიში(ებ)ის წასაშლელად."
 
 #: syslog_reports.php:175
 msgid "Delete Syslog Report(s)"
@@ -1480,7 +1492,7 @@ msgstr "Syslog-ის ანგარიშების წაშლა"
 
 #: syslog_reports.php:179
 msgid "Click 'Continue' to Disable the following Syslog Report(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“, რათა გამორთოთ შემდეგი Syslog ანგარიში(ები)."
 
 #: syslog_reports.php:185
 msgid "Disable Syslog Report(s)"
@@ -1488,7 +1500,7 @@ msgstr "Syslog-ის ანგარიშების გათიშვა"
 
 #: syslog_reports.php:189
 msgid "Click 'Continue' to Enable the following Syslog Report(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“ შემდეგი Syslog ანგარიში(ებ)ის გასააქტიურებლად."
 
 #: syslog_reports.php:195
 msgid "Enable Syslog Report(s)"
@@ -1496,15 +1508,15 @@ msgstr "Syslog-ის ანგარიშების ჩართვა"
 
 #: syslog_reports.php:199
 msgid "Click 'Continue' to Export the following Syslog Report Rule(s)."
-msgstr ""
+msgstr "დააწკაპუნეთ „გაგრძელებაზე“ შემდეგი Syslog ანგარიშის წესი(ებ)ის ექსპორტისთვის."
 
 #: syslog_reports.php:205
 msgid "Export Syslog Report Rule(s)"
-msgstr ""
+msgstr "Syslog ანგარიშის ექსპორტის წესები"
 
 #: syslog_reports.php:210
 msgid "You must select at least one Syslog Report."
-msgstr ""
+msgstr "თქვენ უნდა აირჩიოთ მინიმუმ ერთი Syslog ანგარიში."
 
 #: syslog_reports.php:211
 msgid "Return"
@@ -1513,11 +1525,11 @@ msgstr "დაბრუნება"
 #: syslog_reports.php:391
 #, php-format
 msgid "Report Edit [edit: %s]"
-msgstr ""
+msgstr "მოხსენება რედაქტირების შესახებ [რედაქტირება:%s ]"
 
 #: syslog_reports.php:393 syslog_reports.php:398
 msgid "Report Edit [new]"
-msgstr ""
+msgstr "მოხსენება რედაქტირების შესახებ [ახალი]"
 
 #: syslog_reports.php:395 syslog_reports.php:400
 msgid "New Report Record"
@@ -1525,19 +1537,19 @@ msgstr "ახალი ანგარიშის ჩანაწერი"
 
 #: syslog_reports.php:422
 msgid "Please describe this Report."
-msgstr ""
+msgstr "გთხოვთ აღწეროთ ეს ანგარიში."
 
 #: syslog_reports.php:429
 msgid "Is this Report Enabled?"
-msgstr ""
+msgstr "ჩართულია ეს ანგარიში?"
 
 #: syslog_reports.php:437
 msgid "Define how you would like this string matched."
-msgstr ""
+msgstr "განსაზღვრეთ, თუ როგორ გსურთ ეს სტრიქონი შეესაბამებოდეს."
 
 #: syslog_reports.php:445 syslog_reports.php:472
 msgid "The matching component of the syslog message."
-msgstr ""
+msgstr "syslog შეტყობინების შესატყვისი კომპონენტი."
 
 #: syslog_reports.php:452 syslog_reports.php:743
 msgid "Frequency"
@@ -1545,7 +1557,7 @@ msgstr "სიხშირე"
 
 #: syslog_reports.php:453
 msgid "How often should this Report be sent to the distribution list?"
-msgstr ""
+msgstr "რამდენად ხშირად უნდა გაიგზავნოს ეს ანგარიში განაწილების სიაში?"
 
 #: syslog_reports.php:460 syslog_reports.php:744
 msgid "Send Time"
@@ -1553,7 +1565,7 @@ msgstr "გაგზავნის დრო"
 
 #: syslog_reports.php:461
 msgid "What time of day should this report be sent?"
-msgstr ""
+msgstr "დღის რომელ საათზე უნდა გაიგზავნოს ეს ანგარიში?"
 
 #: syslog_reports.php:468
 msgid "Report Format"
@@ -1561,15 +1573,15 @@ msgstr "ანგარიშის ფორმატი"
 
 #: syslog_reports.php:482
 msgid "The information that will be contained in the body of the Report."
-msgstr ""
+msgstr "ინფორმაცია, რომელიც იქნება მოხსენების ტექსტში."
 
 #: syslog_reports.php:501
 msgid "Comma delimited list of Email addresses to send the report to."
-msgstr ""
+msgstr "მძიმით შემოიფარგლება ელფოსტის მისამართების სია, რომლებზეც უნდა გაგზავნოთ ანგარიში."
 
 #: syslog_reports.php:511
 msgid "Space for Notes on the Report"
-msgstr ""
+msgstr "ადგილი მოხსენების შესახებ შენიშვნებისთვის"
 
 #: syslog_reports.php:714
 msgid "Syslog Report Filters"
@@ -1585,23 +1597,23 @@ msgstr "ბოლო გაგზავნილი"
 
 #: syslog_reports.php:776
 msgid "No Syslog Reports Defined"
-msgstr ""
+msgstr "არ არის განსაზღვრული Syslog ანგარიშები"
 
 #: syslog_reports.php:807
 msgid "Import Report Rule from Local File"
-msgstr ""
+msgstr "ანგარიშის წესის იმპორტი ლოკალური ფაილიდან"
 
 #: syslog_reports.php:808
 msgid "If the XML file containing the Report Rule definition data is located on your local machine, select it here."
-msgstr ""
+msgstr "თუ XML ფაილი, რომელიც შეიცავს ანგარიშის წესის განსაზღვრის მონაცემებს, მდებარეობს თქვენს ადგილობრივ აპარატზე, აირჩიეთ აქ."
 
 #: syslog_reports.php:813
 msgid "Import Report Rule from Text"
-msgstr ""
+msgstr "იმპორტი ანგარიშის წესი ტექსტიდან"
 
 #: syslog_reports.php:814
 msgid "If you have the XML file containing the Report Rule definition data as text, you can paste it into this box to import it."
-msgstr ""
+msgstr "თუ თქვენ გაქვთ XML ფაილი, რომელიც შეიცავს ანგარიშის წესის განმარტების მონაცემებს ტექსტად, შეგიძლიათ ჩასვათ იგი ამ ველში მის იმპორტირებისთვის."
 
 #: syslog_reports.php:825
 msgid "Import Report Data"
@@ -1610,9 +1622,9 @@ msgstr "ანგარიშის მონაცემების შემ�
 #: syslog_reports.php:903
 #, php-format
 msgid "NOTE: Report Rule '%s' %s!"
-msgstr ""
+msgstr "შენიშვნა: მოხსენება წესი '%s'%s !"
 
 #: syslog_reports.php:905
 #, php-format
 msgid "ERROR: Report Rule '%s' %s Failed!"
-msgstr ""
+msgstr "შეცდომა: მოხსენება წესი '%s'%s ვერ მოხერხდა!"

--- a/locales/po/sv-SE.po
+++ b/locales/po/sv-SE.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
-msgstr "Project-Id-Version: \nReport-Msgid-Bugs-To: developers@cacti.net\nPOT-Creation-Date: 2025-03-07 14:31-0500\nPO-Revision-Date: 2026-03-16 13:18+0000\nLast-Translator: Daniel Nylander <daniel@danielnylander.se>\nLanguage-Team: Swedish <https://translate.cacti.net/projects/cacti/syslog/sv/>\nLanguage: sv-SE\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n != 1;\nX-Generator: Weblate 5.11.4\n"
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: developers@cacti.net\n"
+"POT-Creation-Date: 2025-03-07 14:31-0500\n"
+"PO-Revision-Date: 2026-03-16 13:18+0000\n"
+"Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
+"Language-Team: Swedish <https://translate.cacti.net/projects/cacti/syslog/sv/>\n"
+"Language: sv-SE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.11.4\n"
 
 #: functions.php:72
 msgid "Save Failed.  Remote Data Collectors in Sync Mode are not allowed to Save Rules.  Save from the Main Cacti Server instead."

--- a/locales/po/vi-VN.po
+++ b/locales/po/vi-VN.po
@@ -18,24 +18,22 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: functions.php:72
-#, fuzzy
 msgid "Save Failed.  Remote Data Collectors in Sync Mode are not allowed to Save Rules.  Save from the Main Cacti Server instead."
-msgstr "Lưu không thành công. Người thu thập dữ liệu từ xa ở Chế độ đồng bộ hóa không được phép Lưu quy tắc. Thay vào đó, hãy lưu từ Máy chủ Xương rồng Chính."
+msgstr "Lưu không thành công.  Người thu thập dữ liệu từ xa ở Chế độ đồng bộ hóa không được phép Lưu quy tắc.  Thay vào đó hãy lưu từ Máy chủ Cacti chính."
 
 #: functions.php:116
-#, fuzzy
 msgid "Please use an HTML Email Client"
-msgstr "Vui lòng sử dụng ứng dụng email HTML"
+msgstr "Vui lòng sử dụng Ứng dụng khách email HTML"
 
 #: functions.php:1304
-#, fuzzy, php-format
+#, php-format
 msgid "Cacti Syslog Threshold Alert '%s' for Host '%s'"
-msgstr "Cảnh báo ngưỡng của Cacti Syslog ' %s'"
+msgstr "Cảnh báo ngưỡng nhật ký hệ thống của Cacti '%s ' cho máy chủ '%s '"
 
 #: functions.php:1306
-#, fuzzy, php-format
+#, php-format
 msgid "Cacti Syslog Threshold Alert '%s'"
-msgstr "Cảnh báo ngưỡng của Cacti Syslog ' %s'"
+msgstr "Cảnh báo ngưỡng nhật ký hệ thống của Cacti '%s '"
 
 #: functions.php:1314 syslog.php:1896 syslog_alerts.php:874
 msgid "Alert Name"
@@ -56,19 +54,18 @@ msgid "Count"
 msgstr "Đếm"
 
 #: functions.php:1318
-#, fuzzy
 msgid "Match String"
-msgstr "Chuỗi kết hợp"
+msgstr "Chuỗi trận đấu"
 
 #: functions.php:1329 functions.php:1368
-#, fuzzy, php-format
+#, php-format
 msgid "Cacti Syslog Alert '%s' for Host '%s'"
-msgstr "Cảnh báo ngưỡng của Cacti Syslog ' %s'"
+msgstr "Cảnh báo nhật ký hệ thống của Cacti '%s ' dành cho máy chủ '%s '"
 
 #: functions.php:1331 functions.php:1370
-#, fuzzy, php-format
+#, php-format
 msgid "Cacti Syslog Alert '%s'"
-msgstr "Thông báo về plugin Cacti Syslog ' %s'"
+msgstr "Cảnh báo nhật ký hệ thống của Cacti '%s '"
 
 #: functions.php:1340
 msgid "Hostname"
@@ -89,35 +86,31 @@ msgid "Message"
 msgstr "Tin nhắn"
 
 #: functions.php:1351
-#, fuzzy, php-format
+#, php-format
 msgid "WARNING: A Syslog Threshold Alert has Been Triggered for Host '%s'"
-msgstr "CẢNH BÁO: Thông báo Đếm Syslog Plugin Đã được kích hoạt"
+msgstr "CẢNH BÁO: Cảnh báo ngưỡng nhật ký hệ thống đã được kích hoạt cho máy chủ '%s '"
 
 #: functions.php:1353
-#, fuzzy
 msgid "WARNING: A Syslog Threshold Alert has Been Triggered"
-msgstr "CẢNH BÁO: Thông báo Đếm Syslog Plugin Đã được kích hoạt"
+msgstr "CẢNH BÁO: Cảnh báo ngưỡng nhật ký hệ thống đã được kích hoạt"
 
 #: functions.php:1360
 msgid "Name:"
 msgstr "Tên:"
 
 #: functions.php:1361 functions.php:1417
-#, fuzzy
 msgid "Severity:"
-msgstr "Mức độ nghiêm trọng"
+msgstr "Mức độ nghiêm trọng:"
 
 #: functions.php:1362
-#, fuzzy
 msgid "Threshold:"
-msgstr "Ngưỡng"
+msgstr "Ngưỡng:"
 
 #: functions.php:1363
 msgid "Count:"
 msgstr "Đếm:"
 
 #: functions.php:1364
-#, fuzzy
 msgid "Message String:"
 msgstr "Chuỗi tin nhắn:"
 
@@ -138,137 +131,115 @@ msgid "Message:"
 msgstr "Tin nhắn:"
 
 #: functions.php:1484
-#, fuzzy
 msgid ", Host:"
-msgstr "Chủ:"
+msgstr ", Chủ nhà:"
 
 #: functions.php:1484 functions.php:1548
-#, fuzzy
 msgid ", URL:"
 msgstr ", URL:"
 
 #: functions.php:1484 functions.php:1548
-#, fuzzy
 msgid "Sev:"
 msgstr "Thứ bảy:"
 
 #: functions.php:1490 functions.php:1544
-#, fuzzy, php-format
+#, php-format
 msgid "Event Alert - %s"
-msgstr "Thông báo sự kiện - %s"
+msgstr "Thông báo sự kiện -%s"
 
 #: functions.php:1548
-#, fuzzy
 msgid ", Count:"
-msgstr "Đếm:"
+msgstr ", Đếm:"
 
 #: functions.php:2091
 msgid "Host"
 msgstr "Host"
 
 #: functions.php:2116
-#, fuzzy, php-format
+#, php-format
 msgid "Event Report - %s"
-msgstr "Báo cáo sự kiện - %s"
+msgstr "Báo cáo sự kiện -%s"
 
 #: setup.php:34
-#, fuzzy
 msgid "Please rename either your config.php.dist or config_local.php.dist files in the syslog directory, and change setup your database before installing."
-msgstr "Vui lòng đổi tên tệp config.php.dist trong thư mục syslog và thay đổi thiết lập cơ sở dữ liệu của bạn trước khi cài đặt."
+msgstr "Vui lòng đổi tên tệp config.php.dist hoặc config_local.php.dist trong thư mục syslog và thay đổi thiết lập cơ sở dữ liệu của bạn trước khi cài đặt."
 
 #: setup.php:274
-#, fuzzy
 msgid "Syslog 2.0 Requires an Entire Reinstall.  Please uninstall Syslog and Remove all Data before Installing.  Migration is possible, but you must plan this in advance.  No automatic migration is supported."
-msgstr "Syslog 2.0 Yêu cầu cài đặt lại toàn bộ. Vui lòng gỡ cài đặt Syslog và xóa tất cả dữ liệu trước khi cài đặt. Di chuyển là có thể, nhưng bạn phải lập kế hoạch này trước. Không có di chuyển tự động được hỗ trợ."
+msgstr "Syslog 2.0 Yêu cầu cài đặt lại toàn bộ.  Vui lòng gỡ cài đặt Syslog và Xóa tất cả dữ liệu trước khi cài đặt.  Có thể di chuyển nhưng bạn phải lập kế hoạch trước cho việc này.  Không hỗ trợ di chuyển tự động."
 
 #: setup.php:862
-#, fuzzy
 msgid "What upgrade/install type do you wish to use"
-msgstr "Bạn muốn sử dụng loại nâng cấp / cài đặt nào"
+msgstr "Bạn muốn sử dụng loại nâng cấp/cài đặt nào"
 
 #: setup.php:863
-#, fuzzy
 msgid "When you have very large tables, performing a Truncate will be much quicker.  If you are concerned about archive data, you can choose either Inline, which will freeze your browser for the period of this upgrade, or background, which will create a background process to bring your old syslog data from a backup table to the new syslog format.  Again this process can take several hours."
-msgstr "Khi bạn có các bảng rất lớn, việc thực hiện Truncate sẽ nhanh hơn nhiều. Nếu bạn lo lắng về dữ liệu lưu trữ, bạn có thể chọn Inline, nó sẽ đóng băng trình duyệt của bạn trong giai đoạn nâng cấp này hoặc nền sẽ tạo quy trình nền để đưa dữ liệu nhật ký hệ thống cũ của bạn từ bảng sao lưu sang định dạng nhật ký hệ thống mới . Một lần nữa quá trình này có thể mất vài giờ."
+msgstr "Khi bạn có các bảng rất lớn, việc thực hiện Cắt bớt sẽ nhanh hơn nhiều.  Nếu lo ngại về dữ liệu lưu trữ, bạn có thể chọn Nội tuyến, thao tác này sẽ đóng băng trình duyệt của bạn trong thời gian nâng cấp này hoặc chế độ nền, thao tác này sẽ tạo quy trình nền để đưa dữ liệu nhật ký hệ thống cũ của bạn từ bảng sao lưu sang định dạng nhật ký hệ thống mới.  Một lần nữa quá trình này có thể mất vài giờ."
 
 #: setup.php:866
-#, fuzzy
 msgid "Truncate Syslog Table"
-msgstr "Bảng rút gọn Syslog"
+msgstr "Cắt bớt bảng nhật ký hệ thống"
 
 #: setup.php:867
-#, fuzzy
 msgid "Inline Upgrade"
 msgstr "Nâng cấp nội tuyến"
 
 #: setup.php:868
-#, fuzzy
 msgid "Background Upgrade"
 msgstr "Nâng cấp nền"
 
 #: setup.php:873
-#, fuzzy
 msgid "Database Storage Engine"
-msgstr "Cơ sở dữ liệu lưu trữ"
+msgstr "Công cụ lưu trữ cơ sở dữ liệu"
 
 #: setup.php:874
 msgid "You have the option to make this a partitioned table by days."
-msgstr ""
+msgstr "Bạn có tùy chọn để biến bảng này thành một bảng được phân vùng theo ngày."
 
 #: setup.php:877
-#, fuzzy
 msgid "MyISAM Storage"
 msgstr "Lưu trữ MyISAM"
 
 #: setup.php:878
-#, fuzzy
 msgid "InnoDB Storage"
 msgstr "Lưu trữ InnoDB"
 
 #: setup.php:883
-#, fuzzy
 msgid "Database Architecture"
 msgstr "Kiến trúc cơ sở dữ liệu"
 
 #: setup.php:884
-#, fuzzy
 msgid "You have the option to make this a partitioned table by days.  You can create multiple partitions per day."
-msgstr "Trong MySQL 5.1.6 trở lên, bạn có tùy chọn để tạo bảng này được phân vùng theo ngày. Trước khi phát hành, bạn chỉ có sẵn cấu trúc bảng truyền thống."
+msgstr "Bạn có tùy chọn để biến bảng này thành một bảng được phân vùng theo ngày.  Bạn có thể tạo nhiều phân vùng mỗi ngày."
 
 #: setup.php:887
-#, fuzzy
 msgid "Traditional Table"
-msgstr "Bảng truyền thống"
+msgstr "Bàn truyền thống"
 
 #: setup.php:888
-#, fuzzy
 msgid "Partitioned Table"
 msgstr "Bảng phân vùng"
 
 #: setup.php:893
-#, fuzzy
 msgid "Retention Policy"
-msgstr "Duy trì chính sách"
+msgstr "Chính sách lưu giữ"
 
 #: setup.php:894
-#, fuzzy
 msgid "Choose how many days of Syslog values you wish to maintain in the database."
 msgstr "Chọn số ngày giá trị Syslog bạn muốn duy trì trong cơ sở dữ liệu."
 
 #: setup.php:914
-#, fuzzy
 msgid "Partitions per Day"
 msgstr "Phân vùng mỗi ngày"
 
 #: setup.php:915
-#, fuzzy
 msgid "Select the number of partitions per day that you wish to create."
 msgstr "Chọn số lượng phân vùng mỗi ngày mà bạn muốn tạo."
 
 #: setup.php:918 setup.php:919 setup.php:920 setup.php:921 setup.php:922
-#, fuzzy, php-format
+#, php-format
 msgid "%d Per Day"
-msgstr "% d mỗi ngày"
+msgstr "%d mỗi ngày"
 
 #: setup.php:927 setup.php:1015
 msgid "Upgrade"
@@ -279,62 +250,52 @@ msgid "Install"
 msgstr "Cài đặt"
 
 #: setup.php:933
-#, fuzzy, php-format
+#, php-format
 msgid "Syslog %s Advisor"
-msgstr "Syslog %s Cố vấn"
+msgstr "Nhật ký hệ thống%s"
 
 #: setup.php:937
-#, fuzzy
 msgid "WARNING: Syslog Upgrade is Time Consuming!!!"
-msgstr "CẢNH BÁO: Nâng cấp Syslog là thời gian tiêu thụ !!!"
+msgstr "CẢNH BÁO: Nâng cấp nhật ký hệ thống tốn nhiều thời gian!!!"
 
 #: setup.php:938
-#, fuzzy
 msgid "The upgrade of the 'main' syslog table can be a very time consuming process.  As such, it is recommended that you either reduce the size of your syslog table prior to upgrading, or choose the background option</p> <p>If you choose the background option, your legacy syslog table will be renamed, and a new syslog table will be created.  Then, an upgrade process will be launched in the background.  Again, this background process can quite a bit of time to complete.  However, your data will be preserved</p> <p>Regardless of your choice, all existing removal and alert rules will be maintained during the upgrade process.</p> <p>Press <b>'Upgrade'</b> to proceed with the upgrade, or <b>'Cancel'</b> to return to the Plugins menu."
-msgstr "Việc nâng cấp bảng nhật ký hệ thống 'chính' có thể là một quá trình rất tốn thời gian. Do đó, bạn nên giảm kích thước của bảng nhật ký hệ thống trước khi nâng cấp hoặc chọn tùy chọn nền </p><p> Nếu bạn chọn tùy chọn nền, bảng syslog cũ của bạn sẽ được đổi tên và bảng syslog mới sẽ được tạo. Sau đó, một quá trình nâng cấp sẽ được đưa ra trong nền. Một lần nữa, quá trình nền này có thể mất một chút thời gian để hoàn thành. Tuy nhiên, dữ liệu của bạn sẽ được bảo tồn </p><p> Bất kể lựa chọn của bạn là gì, tất cả các quy tắc loại bỏ và cảnh báo hiện có sẽ được duy trì trong quá trình nâng cấp. </p><p> Nhấn <b>'Nâng cấp'</b> để tiến hành nâng cấp hoặc <b>'Hủy'</b> để quay lại menu Plugins."
+msgstr "Việc nâng cấp bảng nhật ký hệ thống “chính” có thể là một quá trình rất tốn thời gian.  Do đó, bạn nên giảm kích thước bảng nhật ký hệ thống trước khi nâng cấp hoặc chọn tùy chọn nền</p> <p>Nếu bạn chọn tùy chọn nền, bảng nhật ký hệ thống cũ của bạn sẽ được đổi tên và bảng nhật ký hệ thống mới sẽ được tạo.  Sau đó, quá trình nâng cấp sẽ được khởi chạy ở chế độ nền.  Một lần nữa, quá trình nền này có thể mất khá nhiều thời gian để hoàn thành.  Tuy nhiên, dữ liệu của bạn sẽ được bảo toàn</p> <p>Bất kể lựa chọn của bạn là gì, tất cả các quy tắc cảnh báo và xóa hiện có sẽ được duy trì trong quá trình nâng cấp.</p> <p>Nhấn <b>'Nâng cấp'</b> để tiếp tục nâng cấp hoặc <b>'Hủy'</b> để quay lại menu Plugin."
 
 #: setup.php:941
-#, fuzzy
 msgid "You can also select the retention duration.  Please keep in mind that if you have several hosts logging to syslog, this table can become quite large.  So, if not using partitioning, you might want to keep the size smaller."
-msgstr "Bạn cũng có thể chọn thời gian duy trì. Xin lưu ý rằng nếu bạn có một vài máy chủ đăng nhập vào syslog, bảng này có thể trở nên khá lớn. Vì vậy, nếu không sử dụng phân vùng, bạn có thể muốn giữ kích thước nhỏ hơn."
+msgstr "Bạn cũng có thể chọn thời gian lưu giữ.  Xin lưu ý rằng nếu bạn có một số máy chủ đăng nhập vào nhật ký hệ thống, bảng này có thể trở nên khá lớn.  Vì vậy, nếu không sử dụng phân vùng, bạn có thể muốn giữ kích thước nhỏ hơn."
 
 #: setup.php:941
-#, fuzzy
 msgid "You can also set the MySQL storage engine.  If you have not tuned you system for InnoDB storage properties, it is strongly recommended that you utilize the MyISAM storage engine."
-msgstr "Bạn cũng có thể thiết lập công cụ lưu trữ MySQL. Nếu bạn chưa điều chỉnh hệ thống của mình cho các thuộc tính lưu trữ của InnoDB, bạn nên sử dụng công cụ lưu trữ MyISAM."
+msgstr "Bạn cũng có thể thiết lập công cụ lưu trữ MySQL.  Nếu bạn chưa điều chỉnh hệ thống của mình cho các thuộc tính lưu trữ InnoDB, bạn nên sử dụng công cụ lưu trữ MyISAM."
 
 #: setup.php:941
-#, fuzzy
 msgid "You have several options to choose from when installing Syslog.  The first is the Database Architecture.  You should elect to utilize Table Partitioning to prevent the size of the tables from becoming excessive thus slowing queries."
-msgstr "Bạn có một số tùy chọn để lựa chọn khi cài đặt Syslog. Đầu tiên là Kiến trúc cơ sở dữ liệu. Bắt đầu với MySQL 5.1.6, bạn có thể chọn sử dụng Phân vùng bảng để ngăn kích thước của các bảng trở nên quá mức do đó làm chậm truy vấn."
+msgstr "Bạn có một số tùy chọn để lựa chọn khi cài đặt Syslog.  Đầu tiên là Kiến trúc cơ sở dữ liệu.  Bạn nên chọn sử dụng Phân vùng bảng để ngăn kích thước của bảng trở nên quá mức do đó làm chậm các truy vấn."
 
 #: setup.php:945
-#, fuzzy, php-format
+#, php-format
 msgid "Syslog %s Settings"
-msgstr "Cài đặt Syslog %s"
+msgstr "Cài đặt nhật ký hệ thống%s"
 
 #: setup.php:972
-#, fuzzy
 msgid "What uninstall method do you want to use?"
-msgstr "Phương pháp gỡ cài đặt nào bạn muốn sử dụng?"
+msgstr "Bạn muốn sử dụng phương pháp gỡ cài đặt nào?"
 
 #: setup.php:973
-#, fuzzy
 msgid "When uninstalling syslog, you can remove everything, or only components, just in case you plan on re-installing in the future."
-msgstr "Khi gỡ cài đặt syslog, bạn có thể xóa mọi thứ hoặc chỉ các thành phần, trong trường hợp bạn dự định cài đặt lại trong tương lai."
+msgstr "Khi gỡ cài đặt nhật ký hệ thống, bạn có thể xóa mọi thứ hoặc chỉ các thành phần, đề phòng trường hợp bạn định cài đặt lại trong tương lai."
 
 #: setup.php:975
-#, fuzzy
 msgid "Remove Everything (Logs, Tables, Settings)"
 msgstr "Xóa mọi thứ (Nhật ký, bảng, cài đặt)"
 
 #: setup.php:975
-#, fuzzy
 msgid "Syslog Data Only"
 msgstr "Chỉ dữ liệu nhật ký hệ thống"
 
 #: setup.php:995
-#, fuzzy
 msgid "Syslog Uninstall Preferences"
 msgstr "Tùy chọn gỡ cài đặt nhật ký hệ thống"
 
@@ -356,154 +317,126 @@ msgid "General Settings"
 msgstr "Cài đặt chung"
 
 #: setup.php:1074
-#, fuzzy
 msgid "Syslog Enabled"
-msgstr "Syslog kích hoạt"
+msgstr "Đã bật nhật ký hệ thống"
 
 #: setup.php:1075
-#, fuzzy
 msgid "If this checkbox is set, records will be transferred from the Syslog Incoming table to the main syslog table and Alerts and Reports will be enabled.  Please keep in mind that if the system is disabled log entries will still accumulate into the Syslog Incoming table as this is defined by the rsyslog or syslog-ng process."
-msgstr "Nếu hộp kiểm này được đặt, các bản ghi sẽ được chuyển từ bảng Syslog đến bảng syslog chính và Cảnh báo và Báo cáo sẽ được bật. Xin lưu ý rằng nếu hệ thống bị vô hiệu hóa, các mục nhật ký sẽ vẫn tích lũy vào bảng Syslog In chuẩn vì điều này được xác định bởi quy trình rsyslog hoặc syslog-ng."
+msgstr "Nếu hộp kiểm này được đặt, các bản ghi sẽ được chuyển từ bảng Syslog Incoming bảng sang bảng syslog chính và Cảnh báo cũng như Báo cáo sẽ được bật.  Xin lưu ý rằng nếu hệ thống bị vô hiệu hóa, các mục nhật ký vẫn sẽ tích lũy vào bảng Syslog Incoming vì bảng này được xác định bởi quy trình rsyslog hoặc syslog-ng."
 
 #: setup.php:1080
-#, fuzzy
 msgid "Enable Statistics Gathering"
-msgstr "Cho phép thu thập số liệu thống kê"
+msgstr "Bật thu thập số liệu thống kê"
 
 #: setup.php:1081
-#, fuzzy
 msgid "If this checkbox is set, statistics on where syslog messages are arriving from will be maintained.  This statistical information can be used to render things such as heat maps."
-msgstr "Nếu hộp kiểm này được đặt, số liệu thống kê về nơi thông báo nhật ký hệ thống sẽ được duy trì. Thông tin thống kê này có thể được sử dụng để hiển thị những thứ như bản đồ nhiệt."
+msgstr "Nếu hộp kiểm này được đặt, số liệu thống kê về nơi gửi thông báo nhật ký hệ thống sẽ được duy trì.  Thông tin thống kê này có thể được sử dụng để hiển thị những thứ như bản đồ nhiệt."
 
 #: setup.php:1086
-#, fuzzy
 msgid "Strip Domains"
-msgstr "Dải tên miền"
+msgstr "Tách tên miền"
 
 #: setup.php:1087
-#, fuzzy
 msgid "A comma delimited list of domains that you wish to remove from the syslog hostname, Examples would be 'mydomain.com, otherdomain.com'"
-msgstr "Danh sách các tên miền được phân tách bằng dấu phẩy mà bạn muốn xóa khỏi tên máy chủ syslog, Ví dụ sẽ là 'mydomain.com, otherdomain.com'"
+msgstr "Danh sách các miền được phân tách bằng dấu phẩy mà bạn muốn xóa khỏi tên máy chủ nhật ký hệ thống, Ví dụ: 'mydomain.com, otherdomain.com'"
 
 #: setup.php:1094
-#, fuzzy
 msgid "Validate Hostnames"
 msgstr "Xác thực tên máy chủ"
 
 #: setup.php:1095
-#, fuzzy
 msgid "If this checkbox is set, all hostnames are validated.  If the hostname is not valid. All records are assigned to a special host called 'invalidhost'.  This setting can impact syslog processing time on large systems.  Therefore, use of this setting should only be used when other means are not in place to prevent this from happening."
-msgstr "Nếu hộp kiểm này được đặt, tất cả tên máy chủ được xác thực. Nếu tên máy chủ không hợp lệ. Tất cả các bản ghi được gán cho một máy chủ đặc biệt gọi là 'không hợp lệ'. Cài đặt này có thể ảnh hưởng đến thời gian xử lý nhật ký hệ thống trên các hệ thống lớn. Do đó, chỉ nên sử dụng cài đặt này khi không có phương tiện khác để ngăn điều này xảy ra."
+msgstr "Nếu hộp kiểm này được đặt, tất cả tên máy chủ đều được xác thực.  Nếu tên máy chủ không hợp lệ. Tất cả các bản ghi được gán cho một máy chủ đặc biệt gọi là 'invalidhost'.  Cài đặt này có thể ảnh hưởng đến thời gian xử lý nhật ký hệ thống trên các hệ thống lớn.  Do đó, chỉ nên sử dụng cài đặt này khi không có sẵn các phương tiện khác để ngăn điều này xảy ra."
 
 #: setup.php:1100
 msgid "Refresh Interval"
 msgstr "Thời gian cập nhật"
 
 #: setup.php:1101
-#, fuzzy
 msgid "This is the time in seconds before the page refreshes."
-msgstr "Đây là thời gian tính bằng giây trước khi trang làm mới."
+msgstr "Đây là thời gian tính bằng giây trước khi trang được làm mới."
 
 #: setup.php:1107
-#, fuzzy
 msgid "Max Report Records"
-msgstr "Hồ sơ báo cáo tối đa"
+msgstr "Bản ghi báo cáo tối đa"
 
 #: setup.php:1108
-#, fuzzy
 msgid "For Threshold based Alerts, what is the maximum number that you wish to show in the report.  This is used to limit the size of the html log and Email."
-msgstr "Đối với Cảnh báo dựa trên Ngưỡng, số lượng tối đa bạn muốn hiển thị trong báo cáo là bao nhiêu. Điều này được sử dụng để giới hạn kích thước của nhật ký html và Email."
+msgstr "Đối với Cảnh báo dựa trên Ngưỡng, số lượng tối đa bạn muốn hiển thị trong báo cáo là bao nhiêu.  Điều này được sử dụng để giới hạn kích thước của nhật ký html và Email."
 
 #: setup.php:1112 setup.php:1113 setup.php:1114 setup.php:1115 setup.php:1116
 #: setup.php:1117
-#, fuzzy, php-format
+#, php-format
 msgid "%d Records"
-msgstr "% d Hồ sơ"
+msgstr "Bản ghi%d"
 
 #: setup.php:1121
-#, fuzzy
 msgid "Command for Opening Tickets"
 msgstr "Lệnh mở vé"
 
 #: setup.php:1122
-#, fuzzy
 msgid "This command will be executed for opening Help Desk Tickets.  The command will be required to parse multiple input parameters as follows: <b>--alert-name</b>, <b>--severity</b>, <b>--hostlist</b>, <b>--message</b>.  The hostlist will be a comma delimited list of hosts impacted by the alert."
-msgstr "Lệnh này sẽ được thực thi để mở Vé trợ giúp. Lệnh sẽ được yêu cầu để phân tích nhiều thông số đầu vào như sau: <b>--alert-tên,</b> <b>--severity,</b> <b>--hostlist,</b> <b>--message.</b> Danh sách máy chủ lưu trữ sẽ là một danh sách được phân tách bằng dấu phẩy của các máy chủ bị ảnh hưởng bởi cảnh báo."
+msgstr "Lệnh này sẽ được thực thi để mở Vé Bộ phận Trợ giúp.  Lệnh sẽ được yêu cầu phân tích nhiều tham số đầu vào như sau: <b>--alert-name</b>, <b>--severity</b>, <b>--hostlist</b>, <b>--message</b>.  Danh sách máy chủ sẽ là danh sách các máy chủ được phân tách bằng dấu phẩy bị ảnh hưởng bởi cảnh báo."
 
 #: setup.php:1128
-#, fuzzy
 msgid "HTML Notification Settings"
-msgstr "Danh sách thông báo"
+msgstr "Cài đặt thông báo HTML"
 
 #: setup.php:1133
-#, fuzzy
 msgid "Enable HTML Based Email"
-msgstr "Email dựa trên HTML"
+msgstr "Kích hoạt email dựa trên HTML"
 
 #: setup.php:1134
-#, fuzzy
 msgid "If this checkbox is set, all Emails will be sent in HTML format.  Otherwise, Emails will be sent in plain text."
-msgstr "Nếu hộp kiểm này được đặt, tất cả các Email sẽ được gửi ở định dạng HTML. Nếu không, Email sẽ được gửi bằng văn bản thuần túy."
+msgstr "Nếu hộp kiểm này được đặt, tất cả Email sẽ được gửi ở định dạng HTML.  Nếu không, Email sẽ được gửi ở dạng văn bản thuần túy."
 
 #: setup.php:1139
-#, fuzzy
 msgid "Format File to Use"
-msgstr "Người dùng bình thường"
+msgstr "Định dạng tệp để sử dụng"
 
 #: setup.php:1142
-#, fuzzy
 msgid "Choose the custom html wrapper and CSS file to use.  This file contains both html and CSS to wrap around your report.  If it contains more than simply CSS, you need to place a special <REPORT> tag inside of the file.  This format tag will be replaced by the report content.  These files are located in the 'formats' directory."
-msgstr "Chọn trình bao bọc html và tệp CSS tùy chỉnh để sử dụng. Tệp này chứa cả html và CSS để bao quanh báo cáo của bạn. Nếu nó chứa nhiều hơn chỉ là CSS, bạn cần phải đặt một<REPORT> thẻ bên trong của tệp. Thẻ định dạng này sẽ được thay thế bằng nội dung báo cáo. Các tệp này nằm trong thư mục 'định dạng'."
+msgstr "Chọn trình bao bọc html tùy chỉnh và tệp CSS để sử dụng.  Tệp này chứa cả html và CSS để bao bọc báo cáo của bạn.  Nếu nó không chỉ chứa CSS, bạn cần đặt một thẻ <BÁO CÁO> đặc biệt bên trong tệp.  Thẻ định dạng này sẽ được thay thế bằng nội dung báo cáo.  Các tệp này nằm trong thư mục 'định dạng'."
 
 #: setup.php:1146
-#, fuzzy
 msgid "Data Retention Settings"
 msgstr "Cài đặt lưu giữ dữ liệu"
 
 #: setup.php:1151
-#, fuzzy
 msgid "Syslog Retention"
-msgstr "Duy trì nhật ký hệ thống"
+msgstr "Lưu giữ nhật ký hệ thống"
 
 #: setup.php:1152
-#, fuzzy
 msgid "This is the number of days to keep events."
-msgstr "Đây là số ngày để giữ sự kiện."
+msgstr "Đây là số ngày để lưu giữ các sự kiện."
 
 #: setup.php:1158
-#, fuzzy
 msgid "Syslog Alert Retention"
-msgstr "Lưu giữ thông báo nhật ký hệ thống"
+msgstr "Lưu giữ cảnh báo nhật ký hệ thống"
 
 #: setup.php:1159
-#, fuzzy
 msgid "This is the number of days to keep alert logs."
-msgstr "Đây là số ngày để giữ nhật ký cảnh báo."
+msgstr "Đây là số ngày để lưu giữ nhật ký cảnh báo."
 
 #: setup.php:1165
-#, fuzzy
 msgid "Remote Message Processing"
-msgstr "Chuỗi tin nhắn:"
+msgstr "Xử lý tin nhắn từ xa"
 
 #: setup.php:1169
-#, fuzzy
 msgid "Enable Remote Data Collector Message Processing"
 msgstr "Bật xử lý tin nhắn của trình thu thập dữ liệu từ xa"
 
 #: setup.php:1170
-#, fuzzy
 msgid "If your Remote Data Collectors have their own Syslog databases and process their messages independently, check this checkbox.  By checking this Checkbox, your Remote Data Collectors will need to maintain their own 'config_local.php' file in order to inform Syslog to use an independent database for message display and processing.  Please use the template file 'config_local.php.dist' for this purpose.  WARNING: Syslog tables will be automatically created as soon as this option is enabled."
-msgstr "Nếu Bộ thu thập dữ liệu từ xa của bạn có cơ sở dữ liệu Syslog của riêng họ và xử lý thư của họ một cách độc lập, hãy chọn hộp kiểm này. Bằng cách chọn Hộp kiểm này, Bộ thu thập dữ liệu từ xa của bạn sẽ cần duy trì tệp 'config_local.php' của riêng họ để thông báo cho Syslog sử dụng cơ sở dữ liệu độc lập để hiển thị và xử lý thông báo. Vui lòng sử dụng tệp mẫu 'config_local.php.dist' cho mục đích này. CẢNH BÁO: Bảng nhật ký sẽ tự động được tạo ngay sau khi tùy chọn này được bật."
+msgstr "Nếu Người thu thập dữ liệu từ xa của bạn có cơ sở dữ liệu Syslog riêng và xử lý tin nhắn của họ một cách độc lập, hãy chọn hộp kiểm này.  Bằng cách chọn Hộp kiểm này, Người thu thập dữ liệu từ xa của bạn sẽ cần duy trì tệp 'config_local.php' của riêng họ để thông báo cho Syslog sử dụng cơ sở dữ liệu độc lập để hiển thị và xử lý thông báo.  Vui lòng sử dụng tệp mẫu 'config_local.php.dist' cho mục đích này.  CẢNH BÁO: Các bảng nhật ký hệ thống sẽ được tạo tự động ngay khi tùy chọn này được bật."
 
 #: setup.php:1175
-#, fuzzy
 msgid "Remote Data Collector Rules Sync"
-msgstr "Đồng bộ hóa quy tắc của trình thu thập dữ liệu từ xa"
+msgstr "Đồng bộ hóa quy tắc thu thập dữ liệu từ xa"
 
 #: setup.php:1176
-#, fuzzy
 msgid "If your Remote Data Collectors have their own Syslog databases and process thrie messages independently, check this checkbox if you wish the Main Cacti databases Alerts, Removal and Report rules to be sent to the Remote Cacti System."
-msgstr "Nếu Bộ thu thập dữ liệu từ xa của bạn có cơ sở dữ liệu Syslog của riêng họ và xử lý thông báo thu thập một cách độc lập, hãy chọn hộp kiểm này nếu bạn muốn các quy tắc Cảnh báo, Xóa và Báo cáo của Cơ sở dữ liệu Xương rồng Chính được gửi đến Hệ thống Xương rồng Từ xa."
+msgstr "Nếu Người thu thập dữ liệu từ xa của bạn có cơ sở dữ liệu Syslog riêng và xử lý ba thông báo một cách độc lập, hãy chọn hộp kiểm này nếu bạn muốn các quy tắc Cảnh báo, xóa và báo cáo của cơ sở dữ liệu Cacti chính được gửi tới Hệ thống Cacti từ xa."
 
 #: setup.php:1249 syslog_removal.php:37
 msgid "Delete"
@@ -522,9 +455,8 @@ msgid "Export"
 msgstr "Xuất ra"
 
 #: setup.php:1295 setup.php:1314
-#, fuzzy
 msgid "Indefinite"
-msgstr "Không xác định"
+msgstr "không xác định"
 
 #: setup.php:1296 setup.php:1315 syslog.php:608 syslog_alerts.php:409
 #, php-format
@@ -541,28 +473,28 @@ msgstr "%d Ngày"
 #: setup.php:1302 setup.php:1321 syslog_alerts.php:411
 #, php-format
 msgid "%d Week"
-msgstr "% d Tuần"
+msgstr "%d Week"
 
 #: setup.php:1303 setup.php:1322 syslog_alerts.php:412
 #, php-format
 msgid "%d Weeks"
-msgstr "% d Tuần"
+msgstr "%d Weeks"
 
 #: setup.php:1304 setup.php:1323
 #, php-format
 msgid "%d Month"
-msgstr "% d Tháng"
+msgstr "%d Month"
 
 #: setup.php:1305 setup.php:1306 setup.php:1307 setup.php:1308 setup.php:1309
 #: setup.php:1324 setup.php:1325 setup.php:1326 setup.php:1327 setup.php:1328
 #, php-format
 msgid "%d Months"
-msgstr "% d Tháng"
+msgstr "%d Months"
 
 #: setup.php:1310 setup.php:1329
 #, php-format
 msgid "%d Year"
-msgstr "% d Năm"
+msgstr "%d Year"
 
 #: setup.php:1333 syslog_reports.php:769
 msgid "Never"
@@ -594,36 +526,30 @@ msgid "Critical"
 msgstr "Chỉ trích"
 
 #: setup.php:1347
-#, fuzzy
 msgid "Begins with"
-msgstr "bắt đầu là"
+msgstr "Bắt đầu với"
 
 #: setup.php:1348
 msgid "Contains"
 msgstr "Chứa"
 
 #: setup.php:1349
-#, fuzzy
 msgid "Ends with"
-msgstr "kết thúc với"
+msgstr "Kết thúc bằng"
 
 #: setup.php:1350
-#, fuzzy
 msgid "Hostname is"
-msgstr "Tên máy:"
+msgstr "Tên máy chủ là"
 
 #: setup.php:1351
-#, fuzzy
 msgid "Program is"
-msgstr "Chương trình"
+msgstr "Chương trình là"
 
 #: setup.php:1352
-#, fuzzy
 msgid "Facility is"
-msgstr "Tiện ích"
+msgstr "Cơ sở vật chất là"
 
 #: setup.php:1353
-#, fuzzy
 msgid "SQL Expression"
 msgstr "Biểu thức SQL"
 
@@ -640,22 +566,18 @@ msgid "Import/Export"
 msgstr "Nhập vào/Xuất ra"
 
 #: setup.php:1383
-#, fuzzy
 msgid "Alert Rules"
 msgstr "Quy tắc cảnh báo"
 
 #: setup.php:1383 setup.php:1384 setup.php:1385 setup.php:1390
-#, fuzzy
 msgid "Syslog Settings"
 msgstr "Cài đặt nhật ký hệ thống"
 
 #: setup.php:1384
-#, fuzzy
 msgid "Removal Rules"
-msgstr "Quy tắc loại bỏ"
+msgstr "Quy tắc xóa"
 
 #: setup.php:1385
-#, fuzzy
 msgid "Report Rules"
 msgstr "Quy tắc báo cáo"
 
@@ -668,7 +590,6 @@ msgid "System Administration"
 msgstr "Quản lí hệ thống"
 
 #: setup.php:1411
-#, fuzzy
 msgid "Syslog Removals"
 msgstr "Xóa nhật ký hệ thống"
 
@@ -677,63 +598,53 @@ msgid "(Edit)"
 msgstr "(Sửa)"
 
 #: setup.php:1414 setup.php:1419 setup.php:1423
-#, fuzzy
 msgid "(Actions)"
-msgstr "Hành động"
+msgstr "(Hành động)"
 
 #: setup.php:1416
-#, fuzzy
 msgid "Syslog Alerts"
 msgstr "Cảnh báo nhật ký hệ thống"
 
 #: setup.php:1421
-#, fuzzy
 msgid "Syslog Reports"
 msgstr "Báo cáo nhật ký hệ thống"
 
 #: setup.php:1500
-#, fuzzy
 msgid "Display Syslog in Range"
-msgstr "Hiển thị Syslog trong Phạm vi"
+msgstr "Hiển thị nhật ký hệ thống trong phạm vi"
 
 #: setup.php:1548
-#, fuzzy, php-format
+#, php-format
 msgid "There were %s Device records removed from the Syslog database"
-msgstr "Đã có %s hồ sơ thiết bị bị xóa khỏi cơ sở dữ liệu Syslog"
+msgstr "Đã xóa%s Bản ghi thiết bị khỏi cơ sở dữ liệu Syslog"
 
 #: setup.php:1564
-#, fuzzy
 msgid "Syslog Utilities"
-msgstr "Syslog tiện ích"
+msgstr "Tiện ích nhật ký hệ thống"
 
 #: setup.php:1568
-#, fuzzy
 msgid "Purge Syslog Devices"
-msgstr "Thanh lọc các thiết bị Syslog"
+msgstr "Dọn dẹp thiết bị nhật ký hệ thống"
 
 #: setup.php:1571
-#, fuzzy
 msgid "This menu pick provides a means to remove Devices that are no longer reporting into Cacti's syslog server."
-msgstr "Lựa chọn menu này cung cấp một phương tiện để xóa các Thiết bị không còn báo cáo vào máy chủ nhật ký hệ thống của Cacti."
+msgstr "Lựa chọn menu này cung cấp phương tiện để xóa Thiết bị không còn báo cáo vào máy chủ nhật ký hệ thống của Cacti."
 
 #: syslog.php:58
-#, fuzzy
 msgid "Syslog Viewer"
 msgstr "Trình xem nhật ký hệ thống"
 
 #: syslog.php:61
-#, fuzzy
 msgid "All Text"
 msgstr "Tất cả văn bản"
 
 #: syslog.php:62 syslog.php:63 syslog.php:64 syslog.php:65 syslog.php:66
 #: syslog.php:67
-#, fuzzy, php-format
+#, php-format
 msgid "%d Chars"
-msgstr "% d"
+msgstr "%d Ký tự"
 
 #: syslog.php:171
-#, fuzzy
 msgid "System Logs"
 msgstr "Nhật ký hệ thống"
 
@@ -742,22 +653,18 @@ msgid "Statistics"
 msgstr "Thống kê"
 
 #: syslog.php:175
-#, fuzzy
 msgid "Alert Logs"
 msgstr "Nhật ký cảnh báo"
 
 #: syslog.php:184
-#, fuzzy
 msgid "Selected Alert"
-msgstr "Thông báo được chọn"
+msgstr "Cảnh báo đã chọn"
 
 #: syslog.php:207
-#, fuzzy
 msgid "Syslog Alert View"
-msgstr "Xem thông báo nhật ký hệ thống"
+msgstr "Chế độ xem cảnh báo nhật ký hệ thống"
 
 #: syslog.php:288
-#, fuzzy
 msgid "Syslog Statistics Filter"
 msgstr "Bộ lọc thống kê nhật ký hệ thống"
 
@@ -788,9 +695,8 @@ msgid "Records"
 msgstr "Bản ghi"
 
 #: syslog.php:384
-#, fuzzy
 msgid "No Syslog Statistics Found"
-msgstr "Không tìm thấy thống kê nhật ký hệ thống"
+msgstr "Không tìm thấy số liệu thống kê nhật ký hệ thống"
 
 #: syslog.php:492 syslog.php:1793 syslog.php:1801 syslog.php:1901
 #: syslog_alerts.php:509
@@ -827,14 +733,14 @@ msgid "Time Range"
 msgstr "Phạm vi thời gian"
 
 #: syslog.php:604 syslog_alerts.php:402
-#, fuzzy, php-format
+#, php-format
 msgid "%d Hour"
 msgstr "%d giờ"
 
 #: syslog.php:605 syslog.php:606 syslog.php:607 syslog_alerts.php:403
 #: syslog_alerts.php:404 syslog_alerts.php:405 syslog_alerts.php:406
 #: syslog_alerts.php:407 syslog_alerts.php:408
-#, fuzzy, php-format
+#, php-format
 msgid "%d Hours"
 msgstr "%d giờ"
 
@@ -848,39 +754,35 @@ msgid "Default"
 msgstr "Mặc định"
 
 #: syslog.php:1066
-#, fuzzy, php-format
+#, php-format
 msgid " [ Start: '%s' to End: '%s', Unprocessed Messages: %s ]"
-msgstr "[Bắt đầu: ' %s' đến hết: ' %s', Tin nhắn chưa được xử lý: %s]"
+msgstr "[ Bắt đầu: '%s ' đến Kết thúc: '%s ', Tin nhắn chưa được xử lý:%s ]"
 
 #: syslog.php:1068
-#, fuzzy, php-format
+#, php-format
 msgid "[ Unprocessed Messages: %s ]"
-msgstr "[Tin nhắn chưa được xử lý: %s]"
+msgstr "[ Tin nhắn chưa được xử lý:%s ]"
 
 #: syslog.php:1078
-#, fuzzy
 msgid "Enter a search term"
-msgstr "Nhập một cụm từ tìm kiếm"
+msgstr "Nhập cụm từ tìm kiếm"
 
 #: syslog.php:1090
-#, fuzzy
 msgid "Select Device(s)"
-msgstr "Chọn thiết bị"
+msgstr "Chọn (các) thiết bị"
 
 #: syslog.php:1092
-#, fuzzy
 msgid "Devices Selected"
-msgstr "Thiết bị được chọn"
+msgstr "Thiết bị đã chọn"
 
 #: syslog.php:1095
-#, fuzzy
 msgid "All Devices Selected"
-msgstr "Tất cả các thiết bị được chọn"
+msgstr "Tất cả thiết bị đã chọn"
 
 #: syslog.php:1329
-#, fuzzy, php-format
+#, php-format
 msgid "Syslog Message Filter %s"
-msgstr "Bộ lọc thư Syslog %s"
+msgstr "Bộ lọc tin nhắn nhật ký hệ thống%s"
 
 #: syslog.php:1336
 msgid "Timespan"
@@ -895,41 +797,34 @@ msgid "From"
 msgstr "Từ"
 
 #: syslog.php:1370
-#, fuzzy
 msgid "Start Date Selector"
-msgstr "Ngày bắt đầu chọn"
+msgstr "Bộ chọn ngày bắt đầu"
 
 #: syslog.php:1373
 msgid "To"
 msgstr "Đến"
 
 #: syslog.php:1379
-#, fuzzy
 msgid "End Date Selector"
 msgstr "Bộ chọn ngày kết thúc"
 
 #: syslog.php:1382
-#, fuzzy
 msgid "Shift Time Backward"
-msgstr "Thay đổi thời gian lùi"
+msgstr "Dịch chuyển thời gian lùi lại"
 
 #: syslog.php:1385
-#, fuzzy
 msgid "Define Shifting Interval"
-msgstr "Xác định khoảng thời gian thay đổi"
+msgstr "Xác định khoảng thời gian dịch chuyển"
 
 #: syslog.php:1398
-#, fuzzy
 msgid "Shift Time Forward"
-msgstr "Chuyển thời gian chuyển tiếp"
+msgstr "Chuyển tiếp thời gian"
 
 #: syslog.php:1403
-#, fuzzy
 msgid "Return filter values to their user defined defaults"
-msgstr "Trả về giá trị bộ lọc cho mặc định do người dùng xác định"
+msgstr "Trả về giá trị bộ lọc về giá trị mặc định do người dùng xác định"
 
 #: syslog.php:1404
-#, fuzzy
 msgid "Export Records to CSV"
 msgstr "Xuất bản ghi sang CSV"
 
@@ -938,7 +833,6 @@ msgid "Save"
 msgstr "Lưu"
 
 #: syslog.php:1405
-#, fuzzy
 msgid "Save Default Settings"
 msgstr "Lưu cài đặt mặc định"
 
@@ -947,26 +841,22 @@ msgid "Alerts"
 msgstr "Cảnh báo"
 
 #: syslog.php:1411
-#, fuzzy
 msgid "View Syslog Alert Rules"
 msgstr "Xem quy tắc cảnh báo nhật ký hệ thống"
 
 #: syslog.php:1412
-#, fuzzy
 msgid "Removals"
 msgstr "Xóa"
 
 #: syslog.php:1412
-#, fuzzy
 msgid "View Syslog Removal Rules"
-msgstr "Xem quy tắc xóa Syslog"
+msgstr "Xem quy tắc xóa nhật ký hệ thống"
 
 #: syslog.php:1413 syslog_reports.php:750
 msgid "Reports"
 msgstr "Báo cáo"
 
 #: syslog.php:1413
-#, fuzzy
 msgid "View Syslog Reports"
 msgstr "Xem báo cáo nhật ký hệ thống"
 
@@ -975,56 +865,46 @@ msgid "Devices"
 msgstr "Thiết bị"
 
 #: syslog.php:1441
-#, fuzzy
 msgid "Show All Devices"
-msgstr "Hiển thị tất cả các thiết bị"
+msgstr "Hiển thị tất cả thiết bị"
 
 #: syslog.php:1443
-#, fuzzy
 msgid "Show All Logs"
-msgstr "Hiển thị tất cả các bản ghi"
+msgstr "Hiển thị tất cả nhật ký"
 
 #: syslog.php:1444
-#, fuzzy
 msgid "Threshold Logs"
 msgstr "Nhật ký ngưỡng"
 
 #: syslog.php:1553
-#, fuzzy
 msgid "Display Rows"
 msgstr "Hàng hiển thị"
 
 #: syslog.php:1563
-#, fuzzy
 msgid "Trim"
-msgstr "Xén"
+msgstr "Cắt tỉa"
 
 #: syslog.php:1566
-#, fuzzy
 msgid "Message Trim"
-msgstr "Tin nhắn Trim"
+msgstr "Cắt bớt tin nhắn"
 
 #: syslog.php:1575
 msgid "Refresh"
 msgstr "Làm mới"
 
 #: syslog.php:1596
-#, fuzzy
 msgid "Facilities to filter on"
-msgstr "Thiết bị để lọc"
+msgstr "Cơ sở vật chất để lọc"
 
 #: syslog.php:1597
-#, fuzzy
 msgid "All Facilities"
-msgstr "Tất cả các tiện nghi"
+msgstr "Tất cả cơ sở vật chất"
 
 #: syslog.php:1618
-#, fuzzy
 msgid "Priority Levels"
 msgstr "Mức độ ưu tiên"
 
 #: syslog.php:1619
-#, fuzzy
 msgid "All Priorities"
 msgstr "Tất cả các ưu tiên"
 
@@ -1033,42 +913,36 @@ msgid "Emergency"
 msgstr "Khẩn cấp"
 
 #: syslog.php:1621
-#, fuzzy
 msgid "Alert++"
-msgstr "Cảnh báo"
+msgstr "Cảnh báo++"
 
 #: syslog.php:1622 syslog.php:1694
 msgid "Alert"
 msgstr "Cảnh báo"
 
 #: syslog.php:1623
-#, fuzzy
 msgid "Critical++"
-msgstr "Chỉ trích"
+msgstr "Quan trọng++"
 
 #: syslog.php:1625
-#, fuzzy
 msgid "Error++"
-msgstr "Lỗi:"
+msgstr "Lỗi++"
 
 #: syslog.php:1626 syslog.php:1695
 msgid "Error"
 msgstr "Lỗi"
 
 #: syslog.php:1627
-#, fuzzy
 msgid "Warning++"
-msgstr "LƯU Ý:"
+msgstr "Cảnh báo++"
 
 #: syslog.php:1629
-#, fuzzy
 msgid "Notice++"
-msgstr "Thông báo"
+msgstr "Thông báo++"
 
 #: syslog.php:1631
-#, fuzzy
 msgid "Info++"
-msgstr "Thông tin"
+msgstr "Thông tin++"
 
 #: syslog.php:1632 syslog.php:1698
 msgid "Info"
@@ -1083,24 +957,20 @@ msgid "Record Type"
 msgstr "Loại dữ liệu"
 
 #: syslog.php:1641
-#, fuzzy
 msgid "Removal Handling"
 msgstr "Xử lý loại bỏ"
 
 #: syslog.php:1642
-#, fuzzy
 msgid "All Records"
 msgstr "Tất cả hồ sơ"
 
 #: syslog.php:1643
-#, fuzzy
 msgid "Main Records"
 msgstr "Hồ sơ chính"
 
 #: syslog.php:1644
-#, fuzzy
 msgid "Removed Records"
-msgstr "Hồ sơ bị xóa"
+msgstr "Bản ghi đã xóa"
 
 #: syslog.php:1715
 msgid "Informational"
@@ -1115,68 +985,56 @@ msgid "Unknown"
 msgstr "Không xác định"
 
 #: syslog.php:1860
-#, fuzzy
 msgid "No Syslog Messages"
 msgstr "Không có tin nhắn nhật ký hệ thống"
 
 #: syslog.php:1906
-#, fuzzy
 msgid "Alert Log Rows"
-msgstr "Nhật ký cảnh báo"
+msgstr "Hàng nhật ký cảnh báo"
 
 #: syslog.php:1920
-#, fuzzy
 msgid "Alert Removed"
 msgstr "Đã xóa thông báo"
 
 #: syslog.php:1934
-#, fuzzy
 msgid "No Alert Log Messages"
-msgstr "Không có thông báo Nhật ký thông báo"
+msgstr "Không có thông báo nhật ký cảnh báo"
 
 #: syslog.php:1991 syslog.php:2014 syslog.php:2033 syslog.php:2034
 msgid "All Programs"
 msgstr "Tất cả chương trình"
 
 #: syslog_alerts.php:169
-#, fuzzy
 msgid "Click 'Continue' to Delete the following Syslog Alert Rule(s)."
 msgstr "Nhấp vào 'Tiếp tục' để xóa (các) Quy tắc cảnh báo nhật ký hệ thống sau đây."
 
 #: syslog_alerts.php:175
-#, fuzzy
 msgid "Delete Syslog Alert Rule(s)"
 msgstr "Xóa (các) Quy tắc cảnh báo nhật ký hệ thống"
 
 #: syslog_alerts.php:179
-#, fuzzy
 msgid "Click 'Continue' to Disable the following Syslog Alert Rule(s)."
-msgstr "Nhấp vào 'Tiếp tục' để vô hiệu hóa (các) Quy tắc cảnh báo nhật ký hệ thống sau đây."
+msgstr "Nhấp vào 'Tiếp tục' để tắt (các) Quy tắc cảnh báo nhật ký hệ thống sau đây."
 
 #: syslog_alerts.php:185
-#, fuzzy
 msgid "Disable Syslog Alert Rule(s)"
-msgstr "Vô hiệu hóa (các) Quy tắc cảnh báo nhật ký hệ thống"
+msgstr "Tắt (các) Quy tắc cảnh báo nhật ký hệ thống"
 
 #: syslog_alerts.php:189
-#, fuzzy
 msgid "Click 'Continue' to Enable the following Syslog Alert Rule(s)."
 msgstr "Nhấp vào 'Tiếp tục' để bật (các) Quy tắc cảnh báo nhật ký hệ thống sau đây."
 
 #: syslog_alerts.php:195
-#, fuzzy
 msgid "Enable Syslog Alert Rule(s)"
-msgstr "Kích hoạt quy tắc cảnh báo nhật ký hệ thống"
+msgstr "Bật (các) Quy tắc cảnh báo nhật ký hệ thống"
 
 #: syslog_alerts.php:199
-#, fuzzy
 msgid "Click 'Continue' to Export the following Syslog Alert Rule(s)."
 msgstr "Nhấp vào 'Tiếp tục' để xuất (các) Quy tắc cảnh báo nhật ký hệ thống sau đây."
 
 #: syslog_alerts.php:205
-#, fuzzy
 msgid "Export Syslog Alert Rule(s)"
-msgstr "Xuất quy tắc cảnh báo nhật ký hệ thống"
+msgstr "Xuất (các) Quy tắc cảnh báo nhật ký hệ thống"
 
 #: syslog_alerts.php:208 syslog_removal.php:230 syslog_reports.php:208
 msgid "Continue"
@@ -1184,16 +1042,16 @@ msgstr "Tiếp tục"
 
 #: syslog_alerts.php:309 syslog_reports.php:304
 msgid "The SQL Syntax Entered is invalid.  Please correct your SQL.<br>"
-msgstr ""
+msgstr "Cú pháp SQL đã nhập không hợp lệ.  Vui lòng sửa lỗi SQL của bạn.<br>"
 
 #: syslog_alerts.php:310 syslog_reports.php:305
 #, php-format
 msgid "The Pre-processed SQL is:<br><br> %s"
-msgstr ""
+msgstr "SQL được xử lý trước là:<br><br>%s"
 
 #: syslog_alerts.php:319 syslog_reports.php:314
 msgid "The processed SQL was invalid.  Please correct your SQL"
-msgstr ""
+msgstr "SQL được xử lý không hợp lệ.  Vui lòng sửa SQL của bạn"
 
 #: syslog_alerts.php:386
 msgid "Not Set"
@@ -1208,17 +1066,15 @@ msgid "1 Month"
 msgstr "1 Tháng"
 
 #: syslog_alerts.php:449
-#, fuzzy, php-format
+#, php-format
 msgid "Alert Edit [edit: %s]"
-msgstr "Thông báo Chỉnh sửa [chỉnh sửa: %s]"
+msgstr "Chỉnh sửa cảnh báo [chỉnh sửa:%s ]"
 
 #: syslog_alerts.php:451 syslog_alerts.php:458 syslog_alerts.php:465
-#, fuzzy
 msgid "Alert Edit [new]"
-msgstr "Chỉnh sửa thông báo [mới]"
+msgstr "Cảnh báo Chỉnh sửa [mới]"
 
 #: syslog_alerts.php:463 syslog_alerts.php:467
-#, fuzzy
 msgid "New Alert Rule"
 msgstr "Quy tắc cảnh báo mới"
 
@@ -1235,68 +1091,57 @@ msgid "Name"
 msgstr "Tên"
 
 #: syslog_alerts.php:491
-#, fuzzy
 msgid "Please describe this Alert."
-msgstr "Vui lòng mô tả Thông báo này."
+msgstr "Vui lòng mô tả Cảnh báo này."
 
 #: syslog_alerts.php:499
-#, fuzzy
 msgid "What is the Severity Level of this Alert?"
-msgstr "Mức độ nghiêm trọng của thông báo này là gì?"
+msgstr "Mức độ nghiêm trọng của Cảnh báo này là gì?"
 
 #: syslog_alerts.php:506
-#, fuzzy
 msgid "Reporting Level"
-msgstr "Phương pháp báo cáo"
+msgstr "Cấp độ báo cáo"
 
 #: syslog_alerts.php:507
-#, fuzzy
 msgid "For recording Re-Alert Cycles, should the Alert be tracked at the System or Device level."
-msgstr "Để ghi lại các Chu kỳ Cảnh báo lại, Cảnh báo có được theo dõi ở cấp Hệ thống hoặc Thiết bị hay không."
+msgstr "Để ghi lại Chu kỳ cảnh báo lại, Cảnh báo nên được theo dõi ở cấp Hệ thống hoặc Thiết bị."
 
 #: syslog_alerts.php:509
 msgid "System"
 msgstr "Hệ thống"
 
 #: syslog_alerts.php:514
-#, fuzzy
 msgid "Reporting Method"
 msgstr "Phương pháp báo cáo"
 
 #: syslog_alerts.php:515
-#, fuzzy
 msgid "Define how to Alert on the syslog messages."
-msgstr "Xác định cách thông báo trên các thông báo nhật ký hệ thống."
+msgstr "Xác định cách Cảnh báo về các thông báo nhật ký hệ thống."
 
 #: syslog_alerts.php:517 syslog_alerts.php:901
 msgid "Individual"
 msgstr "Cá nhân"
 
 #: syslog_alerts.php:523
-#, fuzzy
 msgid "For the 'Threshold' method, If the number seen is above this value an Alert will be triggered."
-msgstr "Đối với phương pháp 'Ngưỡng', Nếu số được nhìn thấy cao hơn giá trị này, Thông báo sẽ được kích hoạt."
+msgstr "Đối với phương pháp 'Ngưỡng', nếu số nhìn thấy cao hơn giá trị này thì Cảnh báo sẽ được kích hoạt."
 
 #: syslog_alerts.php:531 syslog_alerts.php:879 syslog_removal.php:703
 #: syslog_reports.php:741
-#, fuzzy
 msgid "Match Type"
-msgstr "Loại so khớp"
+msgstr "Loại đối sánh"
 
 #: syslog_alerts.php:532 syslog_removal.php:442
-#, fuzzy
 msgid "Define how you would like this string matched.  If using the SQL Expression type you may use any valid SQL expression to generate the alarm.  Available fields include 'message', 'facility', 'priority', and 'host'."
-msgstr "Xác định cách bạn muốn chuỗi này khớp. Nếu sử dụng loại Biểu thức SQL, bạn có thể sử dụng bất kỳ biểu thức SQL hợp lệ nào để tạo cảnh báo. Các trường có sẵn bao gồm 'tin nhắn', 'cơ sở', 'ưu tiên' và 'máy chủ'."
+msgstr "Xác định cách bạn muốn chuỗi này khớp.  Nếu sử dụng loại Biểu thức SQL, bạn có thể sử dụng bất kỳ biểu thức SQL hợp lệ nào để tạo cảnh báo.  Các trường có sẵn bao gồm 'tin nhắn', 'cơ sở', 'ưu tiên' và 'máy chủ'."
 
 #: syslog_alerts.php:539 syslog_reports.php:444 syslog_reports.php:471
-#, fuzzy
 msgid "Message Match String"
-msgstr "Chuỗi kết hợp tin nhắn Syslog"
+msgstr "Chuỗi kết hợp tin nhắn"
 
 #: syslog_alerts.php:540 syslog_removal.php:450
-#, fuzzy
 msgid "Enter the matching component of the syslog message, the facility or host name, or the SQL where clause if using the SQL Expression Match Type."
-msgstr "Nhập thành phần phù hợp của thông báo nhật ký hệ thống, tên cơ sở hoặc tên máy chủ hoặc mệnh đề SQL nếu sử dụng Loại đối sánh biểu thức SQL."
+msgstr "Nhập thành phần khớp của thông báo nhật ký hệ thống, tên cơ sở hoặc máy chủ hoặc mệnh đề SQL Where nếu sử dụng Kiểu khớp biểu thức SQL."
 
 #: syslog_alerts.php:550 syslog_alerts.php:553 syslog_alerts.php:721
 #: syslog_alerts.php:878 syslog_removal.php:436 syslog_removal.php:548
@@ -1306,75 +1151,64 @@ msgid "Enabled"
 msgstr "Bật"
 
 #: syslog_alerts.php:551
-#, fuzzy
 msgid "Is this Alert Enabled?"
-msgstr "Thông báo này đã được bật chưa?"
+msgstr "Thông báo này có được bật không?"
 
 #: syslog_alerts.php:553 syslog_removal.php:436 syslog_reports.php:431
 msgid "Disabled"
 msgstr "Vô hiệu hóa"
 
 #: syslog_alerts.php:557
-#, fuzzy
 msgid "Re-Alert Cycle"
 msgstr "Chu kỳ cảnh báo lại"
 
 #: syslog_alerts.php:561
-#, fuzzy
 msgid "Do not resend this alert again for the same host, until this amount of time has elapsed. For threshold based alarms, this applies to all hosts."
-msgstr "Không gửi lại thông báo này cho cùng một máy chủ, cho đến khi hết thời gian này. Đối với báo động dựa trên ngưỡng, điều này áp dụng cho tất cả các máy chủ."
+msgstr "Không gửi lại cảnh báo này cho cùng một máy chủ cho đến khi hết khoảng thời gian này. Đối với cảnh báo dựa trên ngưỡng, điều này áp dụng cho tất cả các máy chủ."
 
 #: syslog_alerts.php:565 syslog_reports.php:508
 msgid "Notes"
 msgstr "Ghi chú"
 
 #: syslog_alerts.php:568
-#, fuzzy
 msgid "Space for Notes on the Alert"
-msgstr "Không gian cho ghi chú trên cảnh báo"
+msgstr "Không gian dành cho ghi chú trên cảnh báo"
 
 #: syslog_alerts.php:576
 msgid "Email Options"
 msgstr "Tùy chọn email"
 
 #: syslog_alerts.php:580 syslog_reports.php:490
-#, fuzzy
 msgid "Notification List"
 msgstr "Danh sách thông báo"
 
 #: syslog_alerts.php:581 syslog_reports.php:491
-#, fuzzy
 msgid "Use the contents of this Notification List to dictate who should be notified and how."
-msgstr "Sử dụng nội dung của Danh sách thông báo này để chỉ định ai sẽ được thông báo và làm thế nào."
+msgstr "Sử dụng nội dung của Danh sách thông báo này để xác định ai sẽ được thông báo và thông báo như thế nào."
 
 #: syslog_alerts.php:589
-#, fuzzy
 msgid "Emails to Notify"
 msgstr "Email để thông báo"
 
 #: syslog_alerts.php:592
-#, fuzzy
 msgid "Please enter a comma delimited list of Email addresses to inform.  If you wish to send out Email to a recipient in SMS format, please prefix that recipient's Email address with <b>'sms@'</b>.  For example, if the recipients SMS address is <b>'2485551212@mycarrier.net'</b>, you would enter it as <b>'sms@2485551212@mycarrier.net'</b> and it will be formatted as an SMS message."
-msgstr "Vui lòng nhập danh sách địa chỉ Email được phân cách bằng dấu phẩy để thông báo. Nếu bạn muốn gửi Email đến người nhận ở định dạng SMS, vui lòng thêm tiền tố địa chỉ Email của người nhận đó bằng <b>'sms @'</b> . Ví dụ: nếu địa chỉ SMS của người nhận là <b>'2485551212@mycarrier.net'</b> , bạn sẽ nhập nó dưới dạng <b>'sms @ 2485551212 @ mycarrier.net'</b> và nó sẽ được định dạng dưới dạng tin nhắn SMS."
+msgstr "Vui lòng nhập danh sách địa chỉ Email được phân cách bằng dấu phẩy để thông báo.  Nếu bạn muốn gửi Email đến người nhận ở định dạng SMS, vui lòng thêm <b>'sms@'</b> vào trước địa chỉ Email của người nhận đó.  Ví dụ: nếu địa chỉ SMS của người nhận là <b>'2485551212@mycarrier.net'</b>, bạn sẽ nhập địa chỉ đó là <b>'sms@2485551212@mycarrier.net'</b> và nó sẽ được định dạng dưới dạng tin nhắn SMS."
 
 #: syslog_alerts.php:598 syslog_reports.php:479
-#, fuzzy
 msgid "Email Body Text"
-msgstr "Body Text"
+msgstr "Nội dung email"
 
 #: syslog_alerts.php:601
-#, fuzzy
 msgid "This information will appear in the body of the Alert just before the Alert details."
-msgstr "Thông tin sẽ được chứa trong phần thân của báo cáo."
+msgstr "Thông tin này sẽ xuất hiện trong phần nội dung của Cảnh báo ngay trước phần chi tiết của Cảnh báo."
 
 #: syslog_alerts.php:613
 msgid "Open Ticket"
 msgstr "Mở Ticket"
 
 #: syslog_alerts.php:614
-#, fuzzy
 msgid "Should a Help Desk Ticket be opened for this Alert.  NOTE: The Ticket command script will be populated with several 'ALERT_' environment variables for convenience."
-msgstr "Nếu một Vé hỗ trợ được mở cho Thông báo này. LƯU Ý: Kịch bản lệnh Ticket sẽ được điền với một số biến môi trường 'ALERT_' để thuận tiện."
+msgstr "Có nên mở Phiếu trợ giúp cho Thông báo này không.  LƯU Ý: Tập lệnh lệnh Vé sẽ được điền sẵn một số biến môi trường 'ALERT_' để thuận tiện."
 
 #: syslog_alerts.php:616 syslog_alerts.php:727 syslog_alerts.php:903
 #: syslog_removal.php:554 syslog_removal.php:724 syslog_reports.php:592
@@ -1393,9 +1227,8 @@ msgid "Command"
 msgstr "Command"
 
 #: syslog_alerts.php:623
-#, fuzzy
 msgid "When an Alert is triggered, run the following command.  The following replacement variables are available <b>'&lt;HOSTNAME&gt;'</b>, <b>'&lt;ALERTID&gt;'</b>, <b>'&lt;MESSAGE&gt;'</b>, <b>'&lt;FACILITY&gt;'</b>, <b>'&lt;PRIORITY&gt;'</b>, <b>'&lt;SEVERITY&gt;'</b>.  Please note that <b>'&lt;HOSTNAME&gt;'</b> is only available on individual thresholds.  These replacement values can appear on the command line, or be gathered from the environment of the script.  When used from the environment, those variables will be prefixed with 'ALERT_'."
-msgstr "Khi Thông báo được kích hoạt, hãy chạy lệnh sau. Các biến thay thế sau có sẵn <b>&#39;&lt;HOSTNAME&gt;&#39;</b> , <b>&#39;&lt;ALERTID&gt;&#39;</b> , <b>&#39;&lt;MESSAGE&gt;&#39;</b> , <b>&#39;&lt;FACILITY&gt;&#39;</b> , <b>&#39;&lt;PRIORITY&gt;&#39;</b> , <b>&#39;&lt;SEVERITY&gt;&#39;</b> . Xin lưu ý rằng <b>&#39;&lt;HOSTNAME&gt;&#39;</b> chỉ khả dụng trên các ngưỡng riêng lẻ."
+msgstr "Khi Cảnh báo được kích hoạt, hãy chạy lệnh sau.  Các biến thay thế sau đây có sẵn <b>'&lt;HOSTNAME&gt;'</b>, <b>'&lt;ALERTID&gt;'</b>, <b>'&lt;MESSAGE&gt;'</b>, <b>'&lt;FACILITY&gt;'</b>, <b>'&lt;PRIORITY&gt;'</b>, <b>'&lt;MỨC ĐỘ NGHIÊM TRỌNG&gt;'</b>.  Xin lưu ý rằng <b>'&lt;HOSTNAME&gt;'</b> chỉ khả dụng ở các ngưỡng riêng lẻ.  Các giá trị thay thế này có thể xuất hiện trên dòng lệnh hoặc được thu thập từ môi trường của tập lệnh.  Khi được sử dụng từ môi trường, các biến đó sẽ có tiền tố là 'ALERT_'."
 
 #: syslog_alerts.php:731 syslog_reports.php:596
 msgid "Rows"
@@ -1407,7 +1240,6 @@ msgid "Import"
 msgstr "Nhập"
 
 #: syslog_alerts.php:849
-#, fuzzy
 msgid "Syslog Alert Filters"
 msgstr "Bộ lọc cảnh báo nhật ký hệ thống"
 
@@ -1416,12 +1248,10 @@ msgid "Method"
 msgstr "Phương thức"
 
 #: syslog_alerts.php:877
-#, fuzzy
 msgid "Threshold Count"
-msgstr "Đếm ngưỡng"
+msgstr "Số ngưỡng"
 
 #: syslog_alerts.php:880 syslog_removal.php:704 syslog_reports.php:742
-#, fuzzy
 msgid "Search String"
 msgstr "Chuỗi tìm kiếm"
 
@@ -1434,158 +1264,134 @@ msgid "Last Modified"
 msgstr "Sửa đổi lần cuối"
 
 #: syslog_alerts.php:883 syslog_removal.php:707 syslog_reports.php:747
-#, fuzzy
 msgid "By User"
-msgstr "Thành viên: "
+msgstr "Theo người dùng"
 
 #: syslog_alerts.php:906
 msgid "Multiple"
 msgstr "Nhiều"
 
 #: syslog_alerts.php:913
-#, fuzzy
 msgid "No Syslog Alerts Defined"
-msgstr "Không có cảnh báo Syslog được xác định"
+msgstr "Không có cảnh báo nhật ký hệ thống nào được xác định"
 
 #: syslog_alerts.php:944
-#, fuzzy
 msgid "Import Alert Rule from Local File"
 msgstr "Nhập quy tắc cảnh báo từ tệp cục bộ"
 
 #: syslog_alerts.php:945
-#, fuzzy
 msgid "If the XML file containing the Alert Rule definition data is located on your local machine, select it here."
 msgstr "Nếu tệp XML chứa dữ liệu định nghĩa Quy tắc cảnh báo nằm trên máy cục bộ của bạn, hãy chọn nó ở đây."
 
 #: syslog_alerts.php:950
-#, fuzzy
 msgid "Import Alert Rule from Text"
 msgstr "Nhập quy tắc cảnh báo từ văn bản"
 
 #: syslog_alerts.php:951
-#, fuzzy
 msgid "If you have the XML file containing the Alert Ruledefinition data as text, you can paste it into this box to import it."
-msgstr "Nếu bạn có tệp XML chứa dữ liệu Định nghĩa cảnh báo dưới dạng văn bản, bạn có thể dán tệp vào hộp này để nhập tệp."
+msgstr "Nếu bạn có tệp XML chứa dữ liệu định nghĩa Quy tắc cảnh báo dưới dạng văn bản, bạn có thể dán tệp đó vào hộp này để nhập dữ liệu."
 
 #: syslog_alerts.php:962
-#, fuzzy
 msgid "Import Alert Rule"
-msgstr "Quy tắc cảnh báo nhập khẩu"
+msgstr "Nhập quy tắc cảnh báo"
 
 #: syslog_alerts.php:1039 syslog_removal.php:861 syslog_reports.php:903
 msgid "Imported"
 msgstr "Đã nhập"
 
 #: syslog_alerts.php:1039
-#, fuzzy, php-format
+#, php-format
 msgid "NOTE: Alert '%s' %s!"
-msgstr "LƯU Ý: Thông báo ' %s' %s!"
+msgstr "LƯU Ý: Cảnh báo '%s '%s !"
 
 #: syslog_alerts.php:1039 syslog_removal.php:861 syslog_reports.php:903
 msgid "Updated"
 msgstr "Đã cập nhật"
 
 #: syslog_alerts.php:1041
-#, fuzzy, php-format
+#, php-format
 msgid "ERROR: Alert '%s' %s Failed!"
-msgstr "LRI: Thông báo ' %s' %s Không thành công!"
+msgstr "LỖI: Cảnh báo '%s '%s Không thành công!"
 
 #: syslog_alerts.php:1041 syslog_removal.php:863 syslog_reports.php:905
 msgid "Update"
 msgstr "Cập nhật"
 
 #: syslog_removal.php:40
-#, fuzzy
 msgid "Reprocess"
 msgstr "Tái chế"
 
 #: syslog_removal.php:181
-#, fuzzy
 msgid "Click 'Continue' to Delete the following Syslog Removal Rule(s)."
 msgstr "Nhấp vào 'Tiếp tục' để xóa (các) Quy tắc xóa nhật ký hệ thống sau đây."
 
 #: syslog_removal.php:187
-#, fuzzy
 msgid "Delete Syslog Removal Rule(s)"
-msgstr "Xóa (các) Quy tắc xóa Syslog"
+msgstr "Xóa (các) Quy tắc xóa nhật ký hệ thống"
 
 #: syslog_removal.php:191
-#, fuzzy
 msgid "Click 'Continue' to Disable the following Syslog Removal Rule(s)."
-msgstr "Nhấp vào 'Tiếp tục' để vô hiệu hóa (các) Quy tắc xóa Syslog sau."
+msgstr "Nhấp vào 'Tiếp tục' để tắt (các) Quy tắc xóa nhật ký hệ thống sau đây."
 
 #: syslog_removal.php:197
-#, fuzzy
 msgid "Disable Syslog Removal Rule(s)"
-msgstr "Vô hiệu hóa (các) Quy tắc xóa Syslog"
+msgstr "Tắt (các) Quy tắc xóa nhật ký hệ thống"
 
 #: syslog_removal.php:201
-#, fuzzy
 msgid "Click 'Continue' to Enable the following Syslog Removal Rule(s)."
-msgstr "Nhấp vào 'Tiếp tục' để bật (các) Quy tắc xóa Syslog sau."
+msgstr "Nhấp vào 'Tiếp tục' để kích hoạt (các) Quy tắc xóa nhật ký hệ thống sau đây."
 
 #: syslog_removal.php:207
-#, fuzzy
 msgid "Enable Syslog Removal Rule(s)"
-msgstr "Kích hoạt quy tắc xóa nhật ký hệ thống"
+msgstr "Kích hoạt (các) Quy tắc xóa nhật ký hệ thống"
 
 #: syslog_removal.php:211
-#, fuzzy
 msgid "Click 'Continue' to Re-process the following Syslog Removal Rule(s)."
-msgstr "Nhấp vào 'Tiếp tục' để xử lý lại (các) Quy tắc xóa Syslog sau."
+msgstr "Nhấp vào 'Tiếp tục' để xử lý lại (các) Quy tắc xóa nhật ký hệ thống sau đây."
 
 #: syslog_removal.php:217
-#, fuzzy
 msgid "Retroactively Process Syslog Removal Rule(s)"
-msgstr "Quy trình loại bỏ Syslog quy trình"
+msgstr "Xử lý hồi tố (các) Quy tắc xóa nhật ký hệ thống"
 
 #: syslog_removal.php:221
-#, fuzzy
 msgid "Click 'Continue' to Export the following Syslog Removal Rule(s)."
-msgstr "Nhấp vào 'Tiếp tục' để xuất (các) Quy tắc xóa Syslog sau."
+msgstr "Nhấp vào 'Tiếp tục' để xuất (các) Quy tắc xóa nhật ký hệ thống sau đây."
 
 #: syslog_removal.php:227
-#, fuzzy
 msgid "Export Syslog Removal Rule(s)"
-msgstr "Xuất quy tắc xóa Syslog"
+msgstr "Xuất (các) Quy tắc xóa nhật ký hệ thống"
 
 #: syslog_removal.php:342
-#, fuzzy, php-format
+#, php-format
 msgid "Rule '%s' resulted in %s/%s messages removed/transferred"
-msgstr "Đã xóa %s tin nhắn và %s tin nhắn được chuyển"
+msgstr "Quy tắc '%s ' dẫn đến tin nhắn%s /%s bị xóa/chuyển"
 
 #: syslog_removal.php:398
-#, fuzzy, php-format
+#, php-format
 msgid "Removal Rule Edit [edit: %s]"
-msgstr "Quy tắc xóa Chỉnh sửa [chỉnh sửa: %s]"
+msgstr "Chỉnh sửa quy tắc xóa [chỉnh sửa:%s ]"
 
 #: syslog_removal.php:400 syslog_removal.php:407
-#, fuzzy
 msgid "Removal Rule Edit [new]"
-msgstr "Quy tắc xóa Chỉnh sửa [mới]"
+msgstr "Chỉnh sửa quy tắc xóa [mới]"
 
 #: syslog_removal.php:402 syslog_removal.php:415
-#, fuzzy
 msgid "New Removal Record"
-msgstr "Bản ghi loại bỏ mới"
+msgstr "Bản ghi xóa mới"
 
 #: syslog_removal.php:411
-#, fuzzy
 msgid "New Removal Rule"
-msgstr "Quy tắc loại bỏ mới"
+msgstr "Quy tắc xóa mới"
 
 #: syslog_removal.php:421
-#, fuzzy
 msgid "Removal Rule Details"
-msgstr "Chi tiết quy tắc loại bỏ"
+msgstr "Chi tiết quy tắc xóa"
 
 #: syslog_removal.php:425
-#, fuzzy
 msgid "Removal Rule Name"
-msgstr "Tên quy tắc loại bỏ"
+msgstr "Tên quy tắc xóa"
 
 #: syslog_removal.php:426
-#, fuzzy
 msgid "Please describe this Removal Rule."
 msgstr "Vui lòng mô tả Quy tắc loại bỏ này."
 
@@ -1594,56 +1400,46 @@ msgid "Enabled?"
 msgstr "Bật?"
 
 #: syslog_removal.php:434
-#, fuzzy
 msgid "Is this Removal Rule Enabled?"
-msgstr "Là quy tắc loại bỏ này được kích hoạt?"
+msgstr "Quy tắc xóa này có được bật không?"
 
 #: syslog_removal.php:441 syslog_reports.php:436
-#, fuzzy
 msgid "String Match Type"
-msgstr "Loại kết hợp chuỗi"
+msgstr "Kiểu khớp chuỗi"
 
 #: syslog_removal.php:449
-#, fuzzy
 msgid "Syslog Message Match String"
-msgstr "Chuỗi kết hợp tin nhắn Syslog"
+msgstr "Chuỗi kết quả tin nhắn trong nhật ký hệ thống"
 
 #: syslog_removal.php:460
-#, fuzzy
 msgid "Method of Removal"
 msgstr "Phương pháp loại bỏ"
 
 #: syslog_removal.php:462 syslog_removal.php:727
-#, fuzzy
 msgid "Deletion"
 msgstr "Xóa"
 
 #: syslog_removal.php:462
-#, fuzzy
 msgid "Transferal"
 msgstr "Chuyển nhượng"
 
 #: syslog_removal.php:466
-#, fuzzy
 msgid "Removal Rule Notes"
-msgstr "Ghi chú quy tắc loại bỏ"
+msgstr "Ghi chú quy tắc xóa"
 
 #: syslog_removal.php:469
-#, fuzzy
 msgid "Space for Notes on the Removal rule"
-msgstr "Không gian cho ghi chú về quy tắc Xóa"
+msgstr "Chỗ trống dành cho Ghi chú về quy tắc Loại bỏ"
 
 #: syslog_removal.php:558 syslog_removal.php:712
 msgid "Rules"
 msgstr "Quy tắc"
 
 #: syslog_removal.php:676
-#, fuzzy
 msgid "Syslog Removal Rule Filters"
-msgstr "Bộ lọc quy tắc loại bỏ nhật ký hệ thống"
+msgstr "Bộ lọc quy tắc xóa nhật ký hệ thống"
 
 #: syslog_removal.php:701
-#, fuzzy
 msgid "Removal Name"
 msgstr "Tên xóa"
 
@@ -1652,170 +1448,141 @@ msgid "Transfer"
 msgstr "Vận chuyển"
 
 #: syslog_removal.php:734
-#, fuzzy
 msgid "No Syslog Removal Rules Defined"
-msgstr "Không có quy tắc xóa Syslog được xác định"
+msgstr "Không có quy tắc xóa nhật ký hệ thống nào được xác định"
 
 #: syslog_removal.php:765
-#, fuzzy
 msgid "Import Removal Rule from Local File"
-msgstr "Nhập quy tắc xóa từ tệp cục bộ"
+msgstr "Quy tắc xóa nhập từ tệp cục bộ"
 
 #: syslog_removal.php:766
-#, fuzzy
 msgid "If the XML file containing the Removal Rule definition data is located on your local machine, select it here."
-msgstr "Nếu tệp XML chứa dữ liệu định nghĩa Quy tắc loại bỏ được đặt trên máy cục bộ của bạn, hãy chọn nó ở đây."
+msgstr "Nếu tệp XML chứa dữ liệu định nghĩa Quy tắc loại bỏ nằm trên máy cục bộ của bạn, hãy chọn tệp đó ở đây."
 
 #: syslog_removal.php:771
-#, fuzzy
 msgid "Import Removal Rule from Text"
-msgstr "Nhập quy tắc xóa khỏi văn bản"
+msgstr "Quy tắc xóa nhập từ văn bản"
 
 #: syslog_removal.php:772
-#, fuzzy
 msgid "If you have the XML file containing the Removal Rule definition data as text, you can paste it into this box to import it."
-msgstr "Nếu bạn có tệp XML chứa dữ liệu định nghĩa Quy tắc loại bỏ dưới dạng văn bản, bạn có thể dán tệp vào hộp này để nhập tệp."
+msgstr "Nếu bạn có tệp XML chứa dữ liệu định nghĩa Quy tắc loại bỏ dưới dạng văn bản, bạn có thể dán tệp đó vào hộp này để nhập dữ liệu."
 
 #: syslog_removal.php:783
-#, fuzzy
 msgid "Import Removal Rule"
 msgstr "Quy tắc loại bỏ nhập khẩu"
 
 #: syslog_removal.php:861
-#, fuzzy, php-format
+#, php-format
 msgid "NOTE: Removal Rule '%s' %s!"
-msgstr "LƯU Ý: Quy tắc xóa ' %s' %s!"
+msgstr "LƯU Ý: Quy tắc xóa '%s '%s !"
 
 #: syslog_removal.php:863
-#, fuzzy, php-format
+#, php-format
 msgid "ERROR: Removal Rule '%s' %s Failed!"
-msgstr "LRI: Quy tắc xóa ' %s' %s Không thành công!"
+msgstr "LỖI: Quy tắc xóa '%s '%s Không thành công!"
 
 #: syslog_reports.php:169
-#, fuzzy
 msgid "Click 'Continue' to Delete the following Syslog Report(s)."
-msgstr "Nhấp vào 'Tiếp tục' để xóa (các) Báo cáo nhật ký hệ thống sau đây."
+msgstr "Nhấp vào 'Tiếp tục' để xóa (các) Báo cáo nhật ký hệ thống sau."
 
 #: syslog_reports.php:175
-#, fuzzy
 msgid "Delete Syslog Report(s)"
-msgstr "Xóa báo cáo nhật ký hệ thống"
+msgstr "Xóa (các) Báo cáo nhật ký hệ thống"
 
 #: syslog_reports.php:179
-#, fuzzy
 msgid "Click 'Continue' to Disable the following Syslog Report(s)."
-msgstr "Nhấp vào 'Tiếp tục' để vô hiệu hóa (các) Báo cáo nhật ký hệ thống sau đây."
+msgstr "Nhấp vào 'Tiếp tục' để tắt (các) Báo cáo nhật ký hệ thống sau."
 
 #: syslog_reports.php:185
-#, fuzzy
 msgid "Disable Syslog Report(s)"
-msgstr "Vô hiệu hóa (các) Báo cáo nhật ký hệ thống"
+msgstr "Tắt (các) Báo cáo nhật ký hệ thống"
 
 #: syslog_reports.php:189
-#, fuzzy
 msgid "Click 'Continue' to Enable the following Syslog Report(s)."
 msgstr "Nhấp vào 'Tiếp tục' để bật (các) Báo cáo nhật ký hệ thống sau."
 
 #: syslog_reports.php:195
-#, fuzzy
 msgid "Enable Syslog Report(s)"
-msgstr "Kích hoạt báo cáo nhật ký hệ thống"
+msgstr "Bật (các) Báo cáo nhật ký hệ thống"
 
 #: syslog_reports.php:199
-#, fuzzy
 msgid "Click 'Continue' to Export the following Syslog Report Rule(s)."
-msgstr "Nhấp vào 'Tiếp tục' để xuất (các) Quy tắc báo cáo nhật ký hệ thống sau đây."
+msgstr "Nhấp vào 'Tiếp tục' để xuất (các) Quy tắc báo cáo nhật ký hệ thống sau."
 
 #: syslog_reports.php:205
-#, fuzzy
 msgid "Export Syslog Report Rule(s)"
-msgstr "Xuất quy tắc báo cáo nhật ký hệ thống"
+msgstr "Xuất (các) Quy tắc báo cáo nhật ký hệ thống"
 
 #: syslog_reports.php:210
-#, fuzzy
 msgid "You must select at least one Syslog Report."
-msgstr "Bạn phải chọn ít nhất một Báo cáo Syslog."
+msgstr "Bạn phải chọn ít nhất một Báo cáo nhật ký hệ thống."
 
 #: syslog_reports.php:211
 msgid "Return"
 msgstr "Trở về trang cài đặt bắt buộc Plugins"
 
 #: syslog_reports.php:391
-#, fuzzy, php-format
+#, php-format
 msgid "Report Edit [edit: %s]"
-msgstr "Báo cáo Chỉnh sửa [chỉnh sửa: %s]"
+msgstr "Báo cáo Chỉnh sửa [chỉnh sửa:%s ]"
 
 #: syslog_reports.php:393 syslog_reports.php:398
-#, fuzzy
 msgid "Report Edit [new]"
-msgstr "Chỉnh sửa báo cáo [mới]"
+msgstr "Báo cáo Chỉnh sửa [mới]"
 
 #: syslog_reports.php:395 syslog_reports.php:400
-#, fuzzy
 msgid "New Report Record"
 msgstr "Bản ghi báo cáo mới"
 
 #: syslog_reports.php:422
-#, fuzzy
 msgid "Please describe this Report."
-msgstr "Hãy mô tả Báo cáo này."
+msgstr "Vui lòng mô tả Báo cáo này."
 
 #: syslog_reports.php:429
-#, fuzzy
 msgid "Is this Report Enabled?"
-msgstr "Báo cáo này đã được bật chưa?"
+msgstr "Báo cáo này có được bật không?"
 
 #: syslog_reports.php:437
-#, fuzzy
 msgid "Define how you would like this string matched."
 msgstr "Xác định cách bạn muốn chuỗi này khớp."
 
 #: syslog_reports.php:445 syslog_reports.php:472
-#, fuzzy
 msgid "The matching component of the syslog message."
-msgstr "Các thành phần phù hợp của thông báo nhật ký hệ thống."
+msgstr "Thành phần phù hợp của thông báo nhật ký hệ thống."
 
 #: syslog_reports.php:452 syslog_reports.php:743
 msgid "Frequency"
 msgstr "Tần số"
 
 #: syslog_reports.php:453
-#, fuzzy
 msgid "How often should this Report be sent to the distribution list?"
-msgstr "Báo cáo này nên được gửi thường xuyên đến danh sách phân phối như thế nào?"
+msgstr "Báo cáo này nên được gửi tới danh sách phân phối với tần suất như thế nào?"
 
 #: syslog_reports.php:460 syslog_reports.php:744
-#, fuzzy
 msgid "Send Time"
 msgstr "Gửi thời gian"
 
 #: syslog_reports.php:461
-#, fuzzy
 msgid "What time of day should this report be sent?"
-msgstr "Báo cáo này nên được gửi vào thời gian nào trong ngày?"
+msgstr "Báo cáo này nên được gửi vào thời điểm nào trong ngày?"
 
 #: syslog_reports.php:468
-#, fuzzy
 msgid "Report Format"
-msgstr "Báo cáo ghi chú"
+msgstr "Định dạng báo cáo"
 
 #: syslog_reports.php:482
-#, fuzzy
 msgid "The information that will be contained in the body of the Report."
-msgstr "Thông tin sẽ được chứa trong phần thân của báo cáo."
+msgstr "Thông tin sẽ được chứa trong nội dung của Báo cáo."
 
 #: syslog_reports.php:501
-#, fuzzy
 msgid "Comma delimited list of Email addresses to send the report to."
 msgstr "Danh sách địa chỉ Email được phân cách bằng dấu phẩy để gửi báo cáo tới."
 
 #: syslog_reports.php:511
-#, fuzzy
 msgid "Space for Notes on the Report"
 msgstr "Không gian cho ghi chú trên báo cáo"
 
 #: syslog_reports.php:714
-#, fuzzy
 msgid "Syslog Report Filters"
 msgstr "Bộ lọc báo cáo nhật ký hệ thống"
 
@@ -1828,41 +1595,35 @@ msgid "Last Sent"
 msgstr "Gửi lần cuối"
 
 #: syslog_reports.php:776
-#, fuzzy
 msgid "No Syslog Reports Defined"
-msgstr "Không có báo cáo Syslog được xác định"
+msgstr "Không có báo cáo nhật ký hệ thống nào được xác định"
 
 #: syslog_reports.php:807
-#, fuzzy
 msgid "Import Report Rule from Local File"
 msgstr "Nhập quy tắc báo cáo từ tệp cục bộ"
 
 #: syslog_reports.php:808
-#, fuzzy
 msgid "If the XML file containing the Report Rule definition data is located on your local machine, select it here."
-msgstr "Nếu tệp XML chứa dữ liệu định nghĩa Quy tắc báo cáo nằm trên máy cục bộ của bạn, hãy chọn nó ở đây."
+msgstr "Nếu tệp XML chứa dữ liệu định nghĩa Quy tắc Báo cáo nằm trên máy cục bộ của bạn, hãy chọn tệp đó ở đây."
 
 #: syslog_reports.php:813
-#, fuzzy
 msgid "Import Report Rule from Text"
 msgstr "Nhập quy tắc báo cáo từ văn bản"
 
 #: syslog_reports.php:814
-#, fuzzy
 msgid "If you have the XML file containing the Report Rule definition data as text, you can paste it into this box to import it."
-msgstr "Nếu bạn có tệp XML chứa dữ liệu định nghĩa Quy tắc báo cáo dưới dạng văn bản, bạn có thể dán tệp vào hộp này để nhập tệp."
+msgstr "Nếu bạn có tệp XML chứa dữ liệu định nghĩa Quy tắc báo cáo dưới dạng văn bản, bạn có thể dán tệp đó vào hộp này để nhập dữ liệu."
 
 #: syslog_reports.php:825
-#, fuzzy
 msgid "Import Report Data"
 msgstr "Nhập dữ liệu báo cáo"
 
 #: syslog_reports.php:903
-#, fuzzy, php-format
+#, php-format
 msgid "NOTE: Report Rule '%s' %s!"
-msgstr "LƯU Ý: Quy tắc báo cáo ' %s' %s!"
+msgstr "LƯU Ý: Quy tắc báo cáo '%s '%s !"
 
 #: syslog_reports.php:905
-#, fuzzy, php-format
+#, php-format
 msgid "ERROR: Report Rule '%s' %s Failed!"
-msgstr "LRI: Quy tắc báo cáo ' %s' %s Không thành công!"
+msgstr "LỖI: Quy tắc báo cáo '%s '%s Không thành công!"

--- a/locales/po/zh-CN.po
+++ b/locales/po/zh-CN.po
@@ -30,12 +30,12 @@ msgstr "请使用HTML电子邮件客户端"
 #: functions.php:1304
 #, fuzzy, php-format
 msgid "Cacti Syslog Threshold Alert '%s' for Host '%s'"
-msgstr "Cacti Syslog插件阈值警报'％s'"
+msgstr "Cacti Syslog插件阈值警报'%s'"
 
 #: functions.php:1306
 #, fuzzy, php-format
 msgid "Cacti Syslog Threshold Alert '%s'"
-msgstr "Cacti Syslog插件阈值警报'％s'"
+msgstr "Cacti Syslog插件阈值警报'%s'"
 
 #: functions.php:1314 syslog.php:1896 syslog_alerts.php:874
 msgid "Alert Name"
@@ -62,12 +62,12 @@ msgstr "匹配字符串"
 #: functions.php:1329 functions.php:1368
 #, fuzzy, php-format
 msgid "Cacti Syslog Alert '%s' for Host '%s'"
-msgstr "Cacti Syslog插件阈值警报'％s'"
+msgstr "Cacti Syslog插件阈值警报'%s'"
 
 #: functions.php:1331 functions.php:1370
 #, fuzzy, php-format
 msgid "Cacti Syslog Alert '%s'"
-msgstr "Cacti Syslog插件警报'％s'"
+msgstr "Cacti Syslog插件警报'%s'"
 
 #: functions.php:1340
 msgid "Hostname"
@@ -152,7 +152,7 @@ msgstr "西弗："
 #: functions.php:1490 functions.php:1544
 #, fuzzy, php-format
 msgid "Event Alert - %s"
-msgstr "事件警报 - ％s"
+msgstr "事件警报 - %s"
 
 #: functions.php:1548
 #, fuzzy
@@ -166,7 +166,7 @@ msgstr "主机"
 #: functions.php:2116
 #, fuzzy, php-format
 msgid "Event Report - %s"
-msgstr "活动报告 - ％s"
+msgstr "活动报告 - %s"
 
 #: setup.php:34
 #, fuzzy
@@ -252,7 +252,7 @@ msgstr "选择您希望每天创建的分区数。"
 #: setup.php:918 setup.php:919 setup.php:920 setup.php:921 setup.php:922
 #, php-format
 msgid "%d Per Day"
-msgstr "％d 每天"
+msgstr "%d 每天"
 
 #: setup.php:927 setup.php:1015
 msgid "Upgrade"
@@ -265,7 +265,7 @@ msgstr "安装"
 #: setup.php:933
 #, fuzzy, php-format
 msgid "Syslog %s Advisor"
-msgstr "Syslog％s顾问"
+msgstr "Syslog%s顾问"
 
 #: setup.php:937
 msgid "WARNING: Syslog Upgrade is Time Consuming!!!"
@@ -291,7 +291,7 @@ msgstr "安装Syslog时有几个选项可供选择。第一个是数据库架构
 #: setup.php:945
 #, fuzzy, php-format
 msgid "Syslog %s Settings"
-msgstr "Syslog％s设置"
+msgstr "Syslog%s设置"
 
 #: setup.php:972
 msgid "What uninstall method do you want to use?"
@@ -662,7 +662,7 @@ msgstr "在范围内显示Syslog"
 #: setup.php:1548
 #, fuzzy, php-format
 msgid "There were %s Device records removed from the Syslog database"
-msgstr "从Syslog数据库中删除了％s设备记录"
+msgstr "从Syslog数据库中删除了%s设备记录"
 
 #: setup.php:1564
 #, fuzzy
@@ -692,7 +692,7 @@ msgstr "所有文字"
 #: syslog.php:67
 #, fuzzy, php-format
 msgid "%d Chars"
-msgstr "％d Chars"
+msgstr "%d Chars"
 
 #: syslog.php:171
 msgid "System Logs"
@@ -810,7 +810,7 @@ msgstr "默认"
 #: syslog.php:1066
 #, php-format
 msgid " [ Start: '%s' to End: '%s', Unprocessed Messages: %s ]"
-msgstr "[开始：'％s'到结尾：'％s'，未处理的消息：％s]"
+msgstr "[开始：'%s'到结尾：'%s'，未处理的消息：%s]"
 
 #: syslog.php:1068
 #, php-format
@@ -839,7 +839,7 @@ msgstr "选择所有设备"
 #: syslog.php:1329
 #, fuzzy, php-format
 msgid "Syslog Message Filter %s"
-msgstr "系统日志消息过滤器％s"
+msgstr "系统日志消息过滤器%s"
 
 #: syslog.php:1336
 msgid "Timespan"
@@ -1160,7 +1160,7 @@ msgstr "1个月"
 #: syslog_alerts.php:449
 #, fuzzy, php-format
 msgid "Alert Edit [edit: %s]"
-msgstr "警报编辑[编辑：％s]"
+msgstr "警报编辑[编辑：%s]"
 
 #: syslog_alerts.php:451 syslog_alerts.php:458 syslog_alerts.php:465
 #, fuzzy
@@ -1424,7 +1424,7 @@ msgstr "导入的"
 #: syslog_alerts.php:1039
 #, fuzzy, php-format
 msgid "NOTE: Alert '%s' %s!"
-msgstr "注意：提醒'％s'％s！"
+msgstr "注意：提醒'%s'%s！"
 
 #: syslog_alerts.php:1039 syslog_removal.php:861 syslog_reports.php:903
 msgid "Updated"
@@ -1433,7 +1433,7 @@ msgstr "更新"
 #: syslog_alerts.php:1041
 #, fuzzy, php-format
 msgid "ERROR: Alert '%s' %s Failed!"
-msgstr "错误：警报'％s'％s失败！"
+msgstr "错误：警报'%s'%s失败！"
 
 #: syslog_alerts.php:1041 syslog_removal.php:863 syslog_reports.php:905
 msgid "Update"
@@ -1496,12 +1496,12 @@ msgstr "导出Syslog删除规则"
 #: syslog_removal.php:342
 #, fuzzy, php-format
 msgid "Rule '%s' resulted in %s/%s messages removed/transferred"
-msgstr "删除了％s消息，并传输了％s消息"
+msgstr "删除了%s消息，并传输了%s消息"
 
 #: syslog_removal.php:398
 #, fuzzy, php-format
 msgid "Removal Rule Edit [edit: %s]"
-msgstr "删除规则编辑[编辑：％s]"
+msgstr "删除规则编辑[编辑：%s]"
 
 #: syslog_removal.php:400 syslog_removal.php:407
 #, fuzzy
@@ -1626,12 +1626,12 @@ msgstr "导入删除规则"
 #: syslog_removal.php:861
 #, fuzzy, php-format
 msgid "NOTE: Removal Rule '%s' %s!"
-msgstr "注意：删除规则'％s'％s！"
+msgstr "注意：删除规则'%s'%s！"
 
 #: syslog_removal.php:863
 #, fuzzy, php-format
 msgid "ERROR: Removal Rule '%s' %s Failed!"
-msgstr "错误：删除规则'％s'％s失败！"
+msgstr "错误：删除规则'%s'%s失败！"
 
 #: syslog_reports.php:169
 #, fuzzy
@@ -1685,7 +1685,7 @@ msgstr "返回"
 #: syslog_reports.php:391
 #, fuzzy, php-format
 msgid "Report Edit [edit: %s]"
-msgstr "报告编辑[编辑：％s]"
+msgstr "报告编辑[编辑：%s]"
 
 #: syslog_reports.php:393 syslog_reports.php:398
 #, fuzzy
@@ -1805,4 +1805,4 @@ msgstr "注意：报告规则"
 #: syslog_reports.php:905
 #, php-format
 msgid "ERROR: Report Rule '%s' %s Failed!"
-msgstr "错误：报告规则'％s'％s失败！"
+msgstr "错误：报告规则'%s'%s失败！"

--- a/locales/po/zh-CN.po
+++ b/locales/po/zh-CN.po
@@ -1800,7 +1800,7 @@ msgstr "导入报告数据"
 #: syslog_reports.php:903
 #, php-format
 msgid "NOTE: Report Rule '%s' %s!"
-msgstr "注意：报告规则"
+msgstr "NOTE: Report Rule '%s' %s!"
 
 #: syslog_reports.php:905
 #, php-format

--- a/locales/po/zh-TW.po
+++ b/locales/po/zh-TW.po
@@ -4,7 +4,19 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
-msgstr "Project-Id-Version: \nReport-Msgid-Bugs-To: developers@cacti.net\nPOT-Creation-Date: 2025-03-07 14:31-0500\nPO-Revision-Date: 2026-01-16 03:18+0000\nLast-Translator: sucharlie <su.charlie@gmail.com>\nLanguage-Team: Chinese (Traditional Han script) <https://translate.cacti.net/projects/cacti/syslog/zh_Hant/>\nLanguage: zh-TW\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=1; plural=0;\nX-Generator: Weblate 5.11.4\n"
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: developers@cacti.net\n"
+"POT-Creation-Date: 2025-03-07 14:31-0500\n"
+"PO-Revision-Date: 2026-01-16 03:18+0000\n"
+"Last-Translator: sucharlie <su.charlie@gmail.com>\n"
+"Language-Team: Chinese (Traditional Han script) <https://translate.cacti.net/projects/cacti/syslog/zh_Hant/>\n"
+"Language: zh-TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.11.4\n"
 
 #: functions.php:72
 #, fuzzy


### PR DESCRIPTION
This PR performs a global search and replace across all localization files to correct full-width Unicode percent signs (`％`) to standard ASCII percent signs (`%`). This ensures PHP's `sprintf()` and `printf()` functions can correctly inject variables into translated strings.