### PR TITLE
Fixing: #298 and #300 - Signal Handler, Table Truncation and CHANGLOG Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 --- develop ---
 
+* issue#199: Duplicate Partition name errors
 * issue#250: Fix date filter persistence by validating before shift_span detection
+* issue#252: hardening: escape device hostname output in syslog view; parameterize alert API functions
+* issue#256: hardening: prevent CSV formula injection and malformed CSV output in exports
 * issue#258: Execute CREATE TABLE SQL correctly during replication sync
+* issue#260: hardening: replace eval-based callback execution in syslog autocomplete JS
 * issue#278: Extract duplicated alert command execution paths in syslog_process_alerts
 * issue#278: Extract alert command execution into shared helper in functions.php; command tokenization now uses preg_split (handles tabs and consecutive spaces); /bin/sh fallback for non-executable command templates removed (use absolute paths with execute bit set)
+* issue#298: syslog poller: lock timeout, signal handler, and earlier partition rotation
+* issue#300: Syslog table drop with no apparent reason
 * issue: Making changes to support Cacti 1.3
 * issue: Don't use MyISAM for non-analytical tables
 * issue: The install advisor for Syslog was broken in current Cacti releases

--- a/setup.php
+++ b/setup.php
@@ -633,7 +633,7 @@ function syslog_setup_table_new($options) {
 	$present = syslog_db_fetch_row("SHOW TABLES FROM `$syslogdb_default` LIKE 'syslog_reports'");
 
 	if (cacti_sizeof($present)) {
-		$newreport = syslog_db_column_exists("$syslogdb_default`.`syslog_reports`", 'body');
+		$newreport = syslog_db_column_exists('syslog_reports', 'body');
 	} else {
 		$newreport = true;
 	}

--- a/setup.php
+++ b/setup.php
@@ -633,7 +633,7 @@ function syslog_setup_table_new($options) {
 	$present = syslog_db_fetch_row("SHOW TABLES FROM `$syslogdb_default` LIKE 'syslog_reports'");
 
 	if (cacti_sizeof($present)) {
-		$newreport = sizeof(syslog_db_fetch_row("SHOW COLUMNS FROM `$syslogdb_default`.`syslog_reports` LIKE 'body'"));
+		$newreport = syslog_db_column_exists("$syslogdb_default`.`syslog_reports`", 'body');
 	} else {
 		$newreport = true;
 	}
@@ -784,6 +784,9 @@ function syslog_setup_table_new($options) {
 			set_config_option($name, $values['default']);
 		}
 	}
+
+	// ensure that the setting if set previously to truncate is switched to upgrade
+	set_config_option('syslog_install_upgrade_type', 'upgrade');
 }
 
 function syslog_replicate_out($data) {

--- a/syslog_process.php
+++ b/syslog_process.php
@@ -39,11 +39,10 @@ syslog_connect();
  * bursts of incoming syslog events
  */
 ini_set('output_buffering', 'Off');
-ini_set('max_runtime', '-1');
 ini_set('max_execution_time', 3600);
 ini_set('memory_limit', '-1');
 
-set_time_limit(0);
+set_time_limit(3600);
 ob_implicit_flush();
 
 global $debug, $syslog_facilities, $syslog_levels;

--- a/syslog_process.php
+++ b/syslog_process.php
@@ -274,7 +274,7 @@ function sig_handler($signo) {
 		case SIGINT:
 			cacti_log("WARNING: Syslog 'master' is shutting down by signal!", false, 'SYSLOG');
 
-			unregister_process('syslog', 'master', $config['poller_id'], getmypid());
+			unregister_process('syslog', 'master', $config['poller_id']);
 
 			exit(1);
 

--- a/syslog_process.php
+++ b/syslog_process.php
@@ -22,6 +22,12 @@
  +-------------------------------------------------------------------------+
 */
 
+if (function_exists('pcntl_async_signals')) {
+	pcntl_async_signals(true);
+} else {
+	declare(ticks = 100);
+}
+
 include(__DIR__ . '/../../include/cli_check.php');
 include_once(__DIR__ . '/functions.php');
 include_once(__DIR__ . '/database.php');
@@ -32,8 +38,13 @@ syslog_connect();
  * Let it run for an hour if it has to, to clear up any big
  * bursts of incoming syslog events
  */
+ini_set('output_buffering', 'Off');
+ini_set('max_runtime', '-1');
 ini_set('max_execution_time', 3600);
 ini_set('memory_limit', '-1');
+
+set_time_limit(0);
+ob_implicit_flush();
 
 global $debug, $syslog_facilities, $syslog_levels;
 
@@ -80,6 +91,12 @@ if (cacti_sizeof($parms)) {
 				exit(1);
 		}
 	}
+}
+
+// install signal handlers for UNIX only
+if (function_exists('pcntl_signal')) {
+	pcntl_signal(SIGTERM, 'sig_handler');
+	pcntl_signal(SIGINT, 'sig_handler');
 }
 
 // record the start time
@@ -241,6 +258,31 @@ syslog_process_log($start_time, $deleted, $incoming, $removed, $xferred, $alerts
 unregister_process('syslog', 'master', $config['poller_id']);
 
 exit(0);
+
+/**
+ * sig_handler - provides a generic means to catch exceptions to the Cacti log.
+ *
+ * @param int $signo The signal that was thrown by the interface.
+ *
+ * @return (void)
+ */
+function sig_handler($signo) {
+	global $config;
+
+	switch ($signo) {
+		case SIGTERM:
+		case SIGINT:
+			cacti_log("WARNING: Syslog 'master' is shutting down by signal!", false, 'SYSLOG');
+
+			unregister_process('syslog', 'master', $config['poller_id'], getmypid());
+
+			exit(1);
+
+			break;
+		default:
+			// ignore all other signals
+	}
+}
 
 /**
  * display_version - displays version information

--- a/syslog_process.php
+++ b/syslog_process.php
@@ -259,9 +259,9 @@ unregister_process('syslog', 'master', $config['poller_id']);
 exit(0);
 
 /**
- * sig_handler - provides a generic means to catch exceptions to the Cacti log.
+ * sig_handler - handles UNIX signals and logs shutdown events to the Cacti log.
  *
- * @param int $signo The signal that was thrown by the interface.
+ * @param int $signo The signal received by the process.
  *
  * @return (void)
  */


### PR DESCRIPTION
* This should stop the table truncation after install, it will flip the table to use the 'upgrade' process over the truncate process.
* Most of the issues around #298 have been corrected with the exception of signal handling in syslog_process which is now addressed.
* Also doing CHANGELOG.md catchup commit