### PR TITLE
Update setup.php,

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -169,7 +169,7 @@ function plugin_syslog_upgrade() {
 }
 
 function syslog_connect() {
-	global $config, $syslog_cnn, $syslogdb_default, $local_db_cnn_id, $remote_db_cnn_id;
+	global $config, $syslog_cnn, $syslogdb_default, $local_db_cnn_id, $remote_db_cnn_id, $syslog_incoming_config;
 
 	syslog_determine_config();
 


### PR DESCRIPTION
Correct error :
php error - Error: Unknown column '' in 'WHERE' #299

Adding $syslog_incoming_config into the global on syslog_connect will resolve the issue.

$syslog_incoming_config is not used here, but it's define by a call to include(SYSLOG_CONFIG)