### PR TITLE
compat: make PHP 8 HTML escaping behavior explicit

### DIFF
--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         os: [ubuntu-latest]
     
     services:
@@ -140,7 +140,9 @@ jobs:
       run: php -v
     
     - name: Run apt-get update
-      run: sudo apt-get update
+      run: |
+        sudo add-apt-repository -y ppa:ondrej/php
+        sudo apt-get update
     
     - name: Install System Dependencies
       run: sudo apt-get install -y apache2 snmp snmpd rrdtool fping libapache2-mod-php${{ matrix.php }}

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
         os: [ubuntu-latest]
     
     services:
@@ -139,8 +139,10 @@ jobs:
     - name: Check PHP version
       run: php -v
     
-    - name: Run apt-get update
+    - name: Add the ondrej PHP repository
       run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
         sudo add-apt-repository -y ppa:ondrej/php
         sudo apt-get update
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 --- develop ---
 
+* issue: Make HTML escaping behavior explicit across PHP 8 versions
 * issue#199: Duplicate Partition name errors
 * issue#250: Fix date filter persistence by validating before shift_span detection
 * issue#252: hardening: escape device hostname output in syslog view; parameterize alert API functions

--- a/setup.php
+++ b/setup.php
@@ -1592,7 +1592,9 @@ function syslog_graph_buttons($graph_elements = []) {
 					$host_id = syslog_db_fetch_cell_prepared('SELECT host_id FROM syslog_hosts ' . $sql_where, $sql_params);
 
 					if ($host_id) {
-						print "<a class='iconLink' href='" . htmlspecialchars($config['url_path'] . 'plugins/syslog/syslog.php?tab=syslog&reset=1&host=' . $host_id . '&date1=' . $date1 . '&date2=' . $date2) . "' title='" . __('Display Syslog in Range', 'syslog') . "'><i class='deviceRecovering fas fa-exclamation-triangle'></i></a><br>";
+						$url = $config['url_path'] . 'plugins/syslog/syslog.php?tab=syslog&reset=1&host=' . $host_id . '&date1=' . $date1 . '&date2=' . $date2;
+
+						print "<a class='iconLink' href='" . htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "' title='" . __('Display Syslog in Range', 'syslog') . "'><i class='deviceRecovering fas fa-exclamation-triangle'></i></a><br>";
 					}
 				}
 			}

--- a/setup.php
+++ b/setup.php
@@ -1594,7 +1594,7 @@ function syslog_graph_buttons($graph_elements = []) {
 					if ($host_id) {
 						$url = $config['url_path'] . 'plugins/syslog/syslog.php?tab=syslog&reset=1&host=' . $host_id . '&date1=' . $date1 . '&date2=' . $date2;
 
-						print "<a class='iconLink' href='" . htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "' title='" . __('Display Syslog in Range', 'syslog') . "'><i class='deviceRecovering fas fa-exclamation-triangle'></i></a><br>";
+						print "<a class='iconLink' href='" . htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "' title='" . htmlspecialchars(__('Display Syslog in Range', 'syslog'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "'><i class='deviceRecovering fas fa-exclamation-triangle'></i></a><br>";
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- Pass explicit ENT_QUOTES | ENT_SUBSTITUTE flags and UTF-8 to the remaining htmlspecialchars() call.
- Preserve PHP 8.1+ behavior while removing the cross-version compatibility finding.
- Record the compatibility cleanup in the develop changelog.

## Audit result

A whole-plugin PHPCompatibility scan for PHP 8.0+ found five findings on develop. This PR resolves the htmlspecialchars() finding. The other four are omitted fputcsv() escape arguments and are already resolved in #326.

## Validation

- setup.php passes PHP lint.
- setup.php is clean under PHPCompatibility with testVersion 8.0-.
- The full pre-push review gate passed.

CI infrastructure repair #329 should merge first so this PR inherits the corrected PHP matrix after rebase.